### PR TITLE
Implement viewModel with Hilt dependency injection

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -63,6 +63,8 @@ dependencies {
     androidTestImplementation 'androidx.test:rules:1.4.0'
     androidTestImplementation 'androidx.test.espresso:espresso-intents:3.4.0'
     androidTestImplementation 'androidx.test.espresso:espresso-contrib:3.4.0'
+    androidTestImplementation "androidx.arch.core:core-testing:2.1.0"
+
 
     // Hilt dependencies
     implementation "com.google.dagger:hilt-android:$hilt_version"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -45,6 +45,7 @@ android {
 dependencies {
 
     implementation 'androidx.core:core-ktx:1.7.0'
+    implementation("androidx.fragment:fragment-ktx:1.4.1")
     implementation 'androidx.appcompat:appcompat:1.4.1'
     implementation 'com.google.android.material:material:1.5.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.3'

--- a/app/src/androidTest/java/com/github/sdp/ratemyepfl/activity/ClassroomsListActivityTest.kt
+++ b/app/src/androidTest/java/com/github/sdp/ratemyepfl/activity/ClassroomsListActivityTest.kt
@@ -17,7 +17,6 @@ import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.sdp.ratemyepfl.R
 import com.github.sdp.ratemyepfl.activity.classrooms.ClassroomsListActivity
-import com.github.sdp.ratemyepfl.activity.classrooms.ROOM_ID
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import org.junit.Rule
@@ -64,7 +63,7 @@ class ClassroomsListActivityTest {
                 )
             )
 
-        intended(hasExtra(ROOM_ID, "CM3"))
+        intended(hasExtra(ClassroomsListActivity.EXTRA_ROOM_ID, "CM3"))
         release()
     }
 

--- a/app/src/androidTest/java/com/github/sdp/ratemyepfl/activity/CourseReviewActivityTest.kt
+++ b/app/src/androidTest/java/com/github/sdp/ratemyepfl/activity/CourseReviewActivityTest.kt
@@ -12,6 +12,7 @@ import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.action.ViewActions.typeText
 import com.github.sdp.ratemyepfl.R
+import com.github.sdp.ratemyepfl.activity.course.CourseReviewActivity
 import com.github.sdp.ratemyepfl.model.review.CourseReview
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json

--- a/app/src/androidTest/java/com/github/sdp/ratemyepfl/activity/CourseReviewActivityTest.kt
+++ b/app/src/androidTest/java/com/github/sdp/ratemyepfl/activity/CourseReviewActivityTest.kt
@@ -79,6 +79,7 @@ class CourseReviewActivityTest {
         scenario.close()
     }
 
+
         
 
 

--- a/app/src/androidTest/java/com/github/sdp/ratemyepfl/activity/CourseReviewActivityTest.kt
+++ b/app/src/androidTest/java/com/github/sdp/ratemyepfl/activity/CourseReviewActivityTest.kt
@@ -20,11 +20,17 @@ import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
 import com.github.sdp.ratemyepfl.model.review.ReviewRating
+import dagger.hilt.android.testing.HiltAndroidRule
+import dagger.hilt.android.testing.HiltAndroidTest
+import org.junit.Rule
 import java.time.LocalDate
 
-
+@HiltAndroidTest
 @RunWith(AndroidJUnit4::class)
 class CourseReviewActivityTest {
+
+    @get:Rule(order = 0)
+    val hiltRule = HiltAndroidRule(this)
 
     @Test
     fun nullCourseCancels() {

--- a/app/src/androidTest/java/com/github/sdp/ratemyepfl/activity/CoursesActivityTest.kt
+++ b/app/src/androidTest/java/com/github/sdp/ratemyepfl/activity/CoursesActivityTest.kt
@@ -10,6 +10,7 @@ import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import com.github.sdp.ratemyepfl.R
+import com.github.sdp.ratemyepfl.activity.course.CourseListActivity
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import org.hamcrest.Matchers.anything
@@ -23,7 +24,7 @@ class CoursesActivityTest {
     val hiltRule = HiltAndroidRule(this)
 
     @get:Rule(order = 1)
-    val testRule = ActivityScenarioRule(CoursesActivity::class.java)
+    val testRule = ActivityScenarioRule(CourseListActivity::class.java)
 
     @Test
     fun isCoursesListViewViewVisibleOnActivityLaunch() {

--- a/app/src/androidTest/java/com/github/sdp/ratemyepfl/activity/MainActivityTest.kt
+++ b/app/src/androidTest/java/com/github/sdp/ratemyepfl/activity/MainActivityTest.kt
@@ -12,6 +12,7 @@ import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import com.github.sdp.ratemyepfl.R
+import com.github.sdp.ratemyepfl.activity.course.CourseReviewActivity
 import com.github.sdp.ratemyepfl.auth.FakeConnectedUser
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest

--- a/app/src/androidTest/java/com/github/sdp/ratemyepfl/activity/ReviewsActivityTest.kt
+++ b/app/src/androidTest/java/com/github/sdp/ratemyepfl/activity/ReviewsActivityTest.kt
@@ -6,6 +6,7 @@ import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import com.github.sdp.ratemyepfl.R
+import com.github.sdp.ratemyepfl.activity.course.CourseReviewListActivity
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import org.junit.Rule
@@ -18,7 +19,7 @@ class ReviewsActivityTest {
     val hiltRule = HiltAndroidRule(this)
 
     @get:Rule(order = 1)
-    val testRule = ActivityScenarioRule(ReviewsActivity::class.java)
+    val testRule = ActivityScenarioRule(CourseReviewListActivity::class.java)
 
     @Test
     fun isCoursesListViewViewVisibleOnActivityLaunch() {

--- a/app/src/androidTest/java/com/github/sdp/ratemyepfl/activity/SplashScreenTest.kt
+++ b/app/src/androidTest/java/com/github/sdp/ratemyepfl/activity/SplashScreenTest.kt
@@ -7,13 +7,11 @@ import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.*
-import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.intent.Intents.*
 import androidx.test.espresso.intent.matcher.IntentMatchers.toPackage
 import androidx.test.espresso.matcher.ViewMatchers.withId
-import androidx.test.espresso.matcher.ViewMatchers.withText
-import androidx.test.ext.junit.rules.ActivityScenarioRule
 import com.github.sdp.ratemyepfl.R
+import com.github.sdp.ratemyepfl.activity.course.CourseReviewActivity
 import com.github.sdp.ratemyepfl.auth.FakeConnectedUser
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest

--- a/app/src/androidTest/java/com/github/sdp/ratemyepfl/viewmodel/CourseReviewViewModelTest.kt
+++ b/app/src/androidTest/java/com/github/sdp/ratemyepfl/viewmodel/CourseReviewViewModelTest.kt
@@ -2,7 +2,7 @@ package com.github.sdp.ratemyepfl.viewmodel
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.lifecycle.SavedStateHandle
-import com.github.sdp.ratemyepfl.activity.CourseReviewActivity
+import com.github.sdp.ratemyepfl.activity.course.CourseReviewActivity
 import com.github.sdp.ratemyepfl.model.items.Course
 import com.github.sdp.ratemyepfl.model.review.CourseReview
 import com.github.sdp.ratemyepfl.model.review.ReviewRating

--- a/app/src/androidTest/java/com/github/sdp/ratemyepfl/viewmodel/CourseReviewViewModelTest.kt
+++ b/app/src/androidTest/java/com/github/sdp/ratemyepfl/viewmodel/CourseReviewViewModelTest.kt
@@ -1,6 +1,172 @@
 package com.github.sdp.ratemyepfl.viewmodel
 
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.lifecycle.SavedStateHandle
+import com.github.sdp.ratemyepfl.activity.CourseReviewActivity
+import com.github.sdp.ratemyepfl.model.items.Course
+import com.github.sdp.ratemyepfl.model.review.CourseReview
+import com.github.sdp.ratemyepfl.model.review.ReviewRating
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import org.junit.Assert
+import org.junit.Rule
+import org.junit.Test
+import java.time.LocalDate
+
 
 class CourseReviewViewModelTest {
+    @get:Rule
+    val instantTaskExecutor = InstantTaskExecutorRule()
+    val course = Course("SWENG", "CS", "Candea", 4, "CS-306")
 
+    private val savedStateHandle: SavedStateHandle = SavedStateHandle().apply {
+        set(CourseReviewActivity.EXTRA_COURSE_IDENTIFIER, Json.encodeToString(course))
+    }
+
+    @Test
+    fun correctlyInitializeTheCourseWithTheBundleState() {
+        val course = Course("Sweng", "CS", "Candea", 4, "CS-306")
+        val savedStateHandle = SavedStateHandle().apply {
+            set(CourseReviewActivity.EXTRA_COURSE_IDENTIFIER, Json.encodeToString(course))
+        }
+        val model = CourseReviewViewModel(savedStateHandle)
+        Assert.assertEquals(course, model.course)
+    }
+
+    @Test
+    fun setRatingCorrectly() {
+        val rating = ReviewRating.AVERAGE
+        val model = CourseReviewViewModel(savedStateHandle)
+        model.setRating(rating)
+        Thread.sleep(DEFAULT_POSTING_TIME)
+        Assert.assertEquals(rating, model.getRating())
+    }
+
+    @Test
+    fun setTitleCorrectly() {
+        val title = "My title"
+        val viewModel = CourseReviewViewModel(savedStateHandle)
+        viewModel.title.postValue(title)
+        Thread.sleep(DEFAULT_POSTING_TIME)
+
+        Assert.assertEquals(title, viewModel.getTitle())
+    }
+
+    @Test
+    fun setCommentCorrectly() {
+        val comment = "My comment"
+        val viewModel = CourseReviewViewModel(savedStateHandle)
+        viewModel.setComment(comment)
+        Assert.assertEquals(comment, viewModel.getComment())
+    }
+
+    @Test
+    fun setDateCorrectly() {
+        val date = LocalDate.of(2022, 3, 9)
+        val viewModel = CourseReviewViewModel(savedStateHandle)
+        viewModel.setDate(date)
+        Thread.sleep(DEFAULT_POSTING_TIME)
+
+        Assert.assertEquals(date, viewModel.getDate())
+    }
+
+    @Test
+    fun correctlyReviewWhenUserEntersRatingTitleCommentAndDate() {
+        val viewModel = CourseReviewViewModel(savedStateHandle)
+        val rating = ReviewRating.AVERAGE
+        val title = "My title"
+        val comment = "My comment"
+        val date = LocalDate.of(2022, 3, 9)
+
+        val review = viewModel.apply {
+            this.setRating(rating)
+            this.setTitle(title)
+            this.setComment(comment)
+            this.setDate(date)
+            Thread.sleep(DEFAULT_POSTING_TIME)
+        }.review()
+
+        Assert.assertEquals(rating, review?.rating)
+        Assert.assertEquals(title, review?.title)
+        Assert.assertEquals(comment, review?.comment)
+        Assert.assertEquals(date, review?.date)
+    }
+
+    @Test
+    fun returnNullWhenRatingIsMissing() {
+        val viewModel = CourseReviewViewModel(savedStateHandle)
+        val title = "My title"
+        val comment = "My comment"
+        val date = LocalDate.of(2022, 3, 9)
+
+        val review = viewModel.apply {
+            this.setTitle(title)
+            this.setComment(comment)
+            this.setDate(date)
+            Thread.sleep(DEFAULT_POSTING_TIME)
+        }.review()
+
+        Assert.assertEquals(null, review)
+    }
+
+    @Test
+    fun returnNullWhenTitleIsMissing() {
+        val viewModel = CourseReviewViewModel(savedStateHandle)
+        val rating = ReviewRating.AVERAGE
+        val comment = "My comment"
+        val date = LocalDate.of(2022, 3, 9)
+
+        val review = viewModel.apply {
+            this.setRating(rating)
+            this.setComment(comment)
+            this.setDate(date)
+            Thread.sleep(DEFAULT_POSTING_TIME)
+        }.review()
+
+        Assert.assertEquals(null, review)
+    }
+
+    @Test
+    fun returnNullWhenCommentIsMissing() {
+        val viewModel = CourseReviewViewModel(savedStateHandle)
+        val rating = ReviewRating.AVERAGE
+        val title = "My title"
+        val date = LocalDate.of(2022, 3, 9)
+
+        val review = viewModel.apply {
+            this.setTitle(title)
+            this.setRating(rating)
+            this.setDate(date)
+            Thread.sleep(DEFAULT_POSTING_TIME)
+        }.review()
+
+        Assert.assertEquals(null, review)
+    }
+
+    @Test
+    fun usesCurrentDateIfDateIsMissing() {
+        val viewModel = CourseReviewViewModel(savedStateHandle)
+        val rating = ReviewRating.AVERAGE
+        val title = "My title"
+        val comment = "My comment"
+        lateinit var date: LocalDate
+        val review: CourseReview? = viewModel.apply {
+            this.setTitle(title)
+            this.setRating(rating)
+            this.setComment(comment)
+            Thread.sleep(DEFAULT_POSTING_TIME)
+        }.run {
+            date = LocalDate.now()
+            review()
+        }
+
+        Assert.assertEquals(date.year, review?.date?.year)
+        Assert.assertEquals(date.month, review?.date?.month)
+        Assert.assertEquals(date.dayOfMonth, review?.date?.dayOfMonth)
+
+    }
+
+    companion object {
+        const val DEFAULT_POSTING_TIME: Long = 1000
+    }
 }

--- a/app/src/androidTest/java/com/github/sdp/ratemyepfl/viewmodel/CourseReviewViewModelTest.kt
+++ b/app/src/androidTest/java/com/github/sdp/ratemyepfl/viewmodel/CourseReviewViewModelTest.kt
@@ -38,7 +38,6 @@ class CourseReviewViewModelTest {
         val rating = ReviewRating.AVERAGE
         val model = CourseReviewViewModel(savedStateHandle)
         model.setRating(rating)
-        Thread.sleep(DEFAULT_POSTING_TIME)
         Assert.assertEquals(rating, model.getRating())
     }
 
@@ -47,7 +46,6 @@ class CourseReviewViewModelTest {
         val title = "My title"
         val viewModel = CourseReviewViewModel(savedStateHandle)
         viewModel.title.postValue(title)
-        Thread.sleep(DEFAULT_POSTING_TIME)
 
         Assert.assertEquals(title, viewModel.getTitle())
     }
@@ -65,7 +63,6 @@ class CourseReviewViewModelTest {
         val date = LocalDate.of(2022, 3, 9)
         val viewModel = CourseReviewViewModel(savedStateHandle)
         viewModel.setDate(date)
-        Thread.sleep(DEFAULT_POSTING_TIME)
 
         Assert.assertEquals(date, viewModel.getDate())
     }
@@ -83,7 +80,6 @@ class CourseReviewViewModelTest {
             this.setTitle(title)
             this.setComment(comment)
             this.setDate(date)
-            Thread.sleep(DEFAULT_POSTING_TIME)
         }.review()
 
         Assert.assertEquals(rating, review?.rating)
@@ -103,7 +99,6 @@ class CourseReviewViewModelTest {
             this.setTitle(title)
             this.setComment(comment)
             this.setDate(date)
-            Thread.sleep(DEFAULT_POSTING_TIME)
         }.review()
 
         Assert.assertEquals(null, review)
@@ -120,7 +115,6 @@ class CourseReviewViewModelTest {
             this.setRating(rating)
             this.setComment(comment)
             this.setDate(date)
-            Thread.sleep(DEFAULT_POSTING_TIME)
         }.review()
 
         Assert.assertEquals(null, review)
@@ -137,7 +131,6 @@ class CourseReviewViewModelTest {
             this.setTitle(title)
             this.setRating(rating)
             this.setDate(date)
-            Thread.sleep(DEFAULT_POSTING_TIME)
         }.review()
 
         Assert.assertEquals(null, review)
@@ -154,7 +147,6 @@ class CourseReviewViewModelTest {
             this.setTitle(title)
             this.setRating(rating)
             this.setComment(comment)
-            Thread.sleep(DEFAULT_POSTING_TIME)
         }.run {
             date = LocalDate.now()
             review()
@@ -166,7 +158,4 @@ class CourseReviewViewModelTest {
 
     }
 
-    companion object {
-        const val DEFAULT_POSTING_TIME: Long = 1000
-    }
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,11 +16,11 @@
             android:name=".activity.MainActivity"
             android:exported="false" />
         <activity
-            android:name=".activity.ReviewsActivity"
+            android:name=".activity.course.CourseReviewListActivity"
             android:exported="false"
-            android:parentActivityName=".activity.CoursesActivity" />
+            android:parentActivityName=".activity.course.CourseListActivity" />
         <activity
-            android:name=".activity.CoursesActivity"
+            android:name=".activity.course.CourseListActivity"
             android:exported="false"
             android:parentActivityName=".activity.MainActivity" />
         <activity
@@ -28,7 +28,7 @@
             android:exported="false"
             android:parentActivityName=".activity.MainActivity" />
         <activity
-            android:name=".activity.CourseReviewActivity"
+            android:name=".activity.course.CourseReviewActivity"
             android:exported="false"
             android:parentActivityName=".activity.MainActivity" />
         <activity

--- a/app/src/main/java/com/github/sdp/ratemyepfl/activity/CourseMgtActivity.kt
+++ b/app/src/main/java/com/github/sdp/ratemyepfl/activity/CourseMgtActivity.kt
@@ -19,7 +19,8 @@ class CourseMgtActivity : AppCompatActivity() {
     private lateinit var reviewButton: Button
 
     companion object {
-        const val EXTRA_COURSE_REVIEWED = "com.github.sdp.ratemyepfl.model.review.extra_course_reviewed"
+        const val EXTRA_COURSE_REVIEWED =
+            "com.github.sdp.ratemyepfl.model.review.extra_course_reviewed"
         val DEFAULT_COURSE: Course = Course("Sweng", "CS", "Candea", 4, "CS-306")
     }
 

--- a/app/src/main/java/com/github/sdp/ratemyepfl/activity/CourseMgtActivity.kt
+++ b/app/src/main/java/com/github/sdp/ratemyepfl/activity/CourseMgtActivity.kt
@@ -6,6 +6,7 @@ import android.widget.Button
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
 import com.github.sdp.ratemyepfl.R
+import com.github.sdp.ratemyepfl.activity.course.CourseReviewActivity
 import com.github.sdp.ratemyepfl.model.items.Course
 import com.github.sdp.ratemyepfl.model.review.CourseReview
 import kotlinx.serialization.encodeToString

--- a/app/src/main/java/com/github/sdp/ratemyepfl/activity/CourseReviewActivity.kt
+++ b/app/src/main/java/com/github/sdp/ratemyepfl/activity/CourseReviewActivity.kt
@@ -4,10 +4,7 @@ import android.content.Intent
 import android.os.Bundle
 import android.text.Editable
 import android.text.TextWatcher
-import android.widget.Button
-import android.widget.RadioButton
-import android.widget.RadioGroup
-import android.widget.TextView
+import android.widget.*
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import com.github.sdp.ratemyepfl.R
@@ -17,7 +14,6 @@ import com.github.sdp.ratemyepfl.model.review.ReviewRating
 import com.github.sdp.ratemyepfl.viewmodel.CourseReviewViewModel
 import com.google.android.material.textfield.TextInputEditText
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 
@@ -33,7 +29,7 @@ class CourseReviewActivity : AppCompatActivity() {
         const val EXTRA_REVIEW: String = "com.github.sdp.ratemyepfl.model.review.extra_review"
     }
 
-    private lateinit var courseRatingButton: RadioGroup
+    private lateinit var courseRatingRadioGroup: RadioGroup
     private lateinit var courseReviewTitle: TextInputEditText
     private lateinit var courseReviewComment: TextInputEditText
     private lateinit var lastCourseRatingButton: RadioButton
@@ -45,10 +41,11 @@ class CourseReviewActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_course_review)
 
-        courseRatingButton = findViewById(R.id.courseReviewRating)
+        val radioGroupLayout = findViewById<RelativeLayout>(R.id.layoutRadioGroupCourseReview)
+        courseRatingRadioGroup = radioGroupLayout.findViewById(R.id.courseReviewRating)
         courseReviewTitle = findViewById(R.id.courseReviewTitle)
         courseReviewComment = findViewById(R.id.courseReviewOpinion)
-        lastCourseRatingButton = findViewById(R.id.courseRatingExcellentRadioButton)
+        lastCourseRatingButton = radioGroupLayout.findViewById(R.id.courseRatingExcellentRadioButton)
         submitButton = findViewById(R.id.courseReviewSubmit)
         courseReviewIndication = findViewById(R.id.courseReviewCourseName)
 
@@ -87,36 +84,18 @@ class CourseReviewActivity : AppCompatActivity() {
             setError(courseReviewTitle, title, EMPTY_TITLE_MESSAGE)
         }
 
-        courseRatingButton.setOnCheckedChangeListener { _, id ->
+        courseRatingRadioGroup.setOnCheckedChangeListener { _, id ->
             viewModel.setRating(fromIdToRating(id))
         }
 
-        courseReviewTitle.addTextChangedListener(object : TextWatcher {
-            override fun beforeTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) {
-
-            }
-
-            override fun onTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) {
-                viewModel.setTitle(p0.toString())
-            }
-
-            override fun afterTextChanged(p0: Editable?) {
-
-            }
-
+        courseReviewTitle.addTextChangedListener(onTextChangedTextWatcher { charSequence, _, _, _ ->
+            viewModel.setTitle(charSequence.toString())
         })
 
-        courseReviewComment.addTextChangedListener(object : TextWatcher {
-            override fun beforeTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) {
-            }
-
-            override fun onTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) {
-                viewModel.setComment(p0.toString())
-            }
-
-            override fun afterTextChanged(p0: Editable?) {
-            }
-
+        courseReviewComment.addTextChangedListener(onTextChangedTextWatcher { charSequence, _, _, _ ->
+            viewModel.setComment(
+                charSequence.toString()
+            )
         })
 
         submitButton.setOnClickListener { _ ->
@@ -146,4 +125,15 @@ class CourseReviewActivity : AppCompatActivity() {
         R.id.courseRatingExcellentRadioButton -> ReviewRating.EXCELLENT
         else -> null
     }
+
+    private fun onTextChangedTextWatcher(consume: (CharSequence?, Int, Int, Int) -> Unit): TextWatcher =
+        object : TextWatcher {
+            override fun beforeTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) {}
+
+            override fun onTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) {
+                consume(p0, p1, p2, p3)
+            }
+
+            override fun afterTextChanged(p0: Editable?) {}
+        }
 }

--- a/app/src/main/java/com/github/sdp/ratemyepfl/activity/CourseReviewActivity.kt
+++ b/app/src/main/java/com/github/sdp/ratemyepfl/activity/CourseReviewActivity.kt
@@ -71,6 +71,7 @@ class CourseReviewActivity : AppCompatActivity() {
             this.viewModel = viewModel
         } catch (e: IllegalArgumentException) {
             cancelReview()
+            return
         }
 
         courseReviewIndication.text =

--- a/app/src/main/java/com/github/sdp/ratemyepfl/activity/MainActivity.kt
+++ b/app/src/main/java/com/github/sdp/ratemyepfl/activity/MainActivity.kt
@@ -9,6 +9,7 @@ import com.github.sdp.ratemyepfl.auth.Authenticator
 import com.github.sdp.ratemyepfl.auth.ConnectedUser
 import com.github.sdp.ratemyepfl.R
 import com.github.sdp.ratemyepfl.activity.classrooms.ClassroomsListActivity
+import com.github.sdp.ratemyepfl.activity.course.CourseListActivity
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
@@ -53,7 +54,7 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun displayCourses() {
-        val intent = Intent(this, CoursesActivity::class.java)
+        val intent = Intent(this, CourseListActivity::class.java)
         startActivity(intent)
     }
 

--- a/app/src/main/java/com/github/sdp/ratemyepfl/activity/ReviewsActivity.kt
+++ b/app/src/main/java/com/github/sdp/ratemyepfl/activity/ReviewsActivity.kt
@@ -10,7 +10,7 @@ import com.github.sdp.ratemyepfl.model.review.CourseReviewAdapter
 class ReviewsActivity : AppCompatActivity() {
 
     companion object {
-        const val EXTRA_COURSE_NAME: String = "course name"
+        const val EXTRA_COURSE_NAME: String = "com.github.sdp.ratemyepfl.activity.course_name"
     }
 
     private lateinit var reviewsView: ListView

--- a/app/src/main/java/com/github/sdp/ratemyepfl/activity/classrooms/ClassroomsListActivity.kt
+++ b/app/src/main/java/com/github/sdp/ratemyepfl/activity/classrooms/ClassroomsListActivity.kt
@@ -2,6 +2,7 @@ package com.github.sdp.ratemyepfl.activity.classrooms
 
 import android.content.Intent
 import android.os.Bundle
+import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.RecyclerView
@@ -9,21 +10,17 @@ import com.github.sdp.ratemyepfl.model.items.Classroom
 import com.github.sdp.ratemyepfl.R
 import com.github.sdp.ratemyepfl.adapter.ClassroomsAdapter
 import com.github.sdp.ratemyepfl.viewmodel.ClassroomsListViewModel
+import dagger.hilt.android.AndroidEntryPoint
 
-const val ROOM_ID = "room id"
 
+@AndroidEntryPoint
 class ClassroomsListActivity : AppCompatActivity() {
 
-    private lateinit var viewModel: ClassroomsListViewModel
+    private val viewModel: ClassroomsListViewModel by viewModels()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_classrooms_list)
-
-        viewModel = ViewModelProvider(
-            this,
-            ViewModelProvider.NewInstanceFactory()
-        ).get(ClassroomsListViewModel::class.java)
 
         val roomsAdapter = ClassroomsAdapter { room -> adapterOnClick(room) }
         val recyclerView: RecyclerView = findViewById(R.id.rooms_recycler_view)
@@ -41,8 +38,11 @@ class ClassroomsListActivity : AppCompatActivity() {
     /* Opens RoomReviewsActivity when RecyclerView item is clicked. */
     private fun adapterOnClick(room: Classroom) {
         val intent = Intent(this, RoomReviewsListActivity()::class.java)
-        intent.putExtra(ROOM_ID, room.id)
+        intent.putExtra(EXTRA_ROOM_ID, room.id)
         startActivity(intent)
     }
 
+    companion object {
+        const val EXTRA_ROOM_ID = "com.github.sdp.ratemyepfl.activity.classrooms.extra_room_id"
+    }
 }

--- a/app/src/main/java/com/github/sdp/ratemyepfl/activity/classrooms/RoomReviewsListActivity.kt
+++ b/app/src/main/java/com/github/sdp/ratemyepfl/activity/classrooms/RoomReviewsListActivity.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import android.os.Bundle
 import android.view.View
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.recyclerview.widget.RecyclerView
 import com.github.sdp.ratemyepfl.R
@@ -20,31 +21,19 @@ class RoomReviewsListActivity : AppCompatActivity() {
 
     @Inject
     lateinit var dataSource: DataSource
-    lateinit var roomReviewsViewModel: RoomReviewsListViewModel
+    private val viewModel: RoomReviewsListViewModel by viewModels()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_room_reviews_list)
-
-        var currentRoomId: String? = null
-        val bundle: Bundle? = intent.extras
-        if (bundle != null) {
-            currentRoomId = bundle.getString(ROOM_ID)
-        }
-        roomReviewsViewModel = RoomReviewsListViewModel(dataSource, currentRoomId)
-
-        /*roomReviewsViewModel = ViewModelProvider(
-            this,
-            RoomReviewsListViewModel.RoomReviewsListViewModelFactory(DataSource(), currentRoomId)
-        ).get(RoomReviewsListViewModel::class.java)*/
 
         val reviewsAdapter = RoomReviewsAdapter()
         val recyclerView: RecyclerView = findViewById(R.id.review_recycler_view)
         recyclerView.adapter = reviewsAdapter
 
         // Display the reviews of the classroom
-        currentRoomId?.let {
-            roomReviewsViewModel.getReviews().observe(this) {
+        viewModel.id.let {
+            viewModel.getReviews().observe(this) {
                 it?.let {
                     reviewsAdapter.submitList(it as MutableList<ClassroomReview>)
                 }
@@ -72,7 +61,7 @@ class RoomReviewsListActivity : AppCompatActivity() {
                 val roomGrade = d?.getStringExtra(ROOM_GRADE)
                 val roomComment = d?.getStringExtra(ROOM_COMMENT)
                 if (roomGrade != null && roomComment != null) {
-                    roomReviewsViewModel.insertReview(roomGrade, roomComment)
+                    viewModel.insertReview(roomGrade, roomComment)
                 }
             }
         }

--- a/app/src/main/java/com/github/sdp/ratemyepfl/activity/course/CourseListActivity.kt
+++ b/app/src/main/java/com/github/sdp/ratemyepfl/activity/course/CourseListActivity.kt
@@ -10,7 +10,9 @@ import androidx.appcompat.app.AppCompatActivity
 import com.github.sdp.ratemyepfl.R
 import com.github.sdp.ratemyepfl.database.FakeCoursesDatabase
 import com.github.sdp.ratemyepfl.viewmodel.CourseListViewModel
+import dagger.hilt.android.AndroidEntryPoint
 
+@AndroidEntryPoint
 class CourseListActivity : AppCompatActivity() {
 
     private lateinit var coursesView: ListView

--- a/app/src/main/java/com/github/sdp/ratemyepfl/activity/course/CourseListActivity.kt
+++ b/app/src/main/java/com/github/sdp/ratemyepfl/activity/course/CourseListActivity.kt
@@ -1,24 +1,26 @@
-package com.github.sdp.ratemyepfl.activity
+package com.github.sdp.ratemyepfl.activity.course
 
 import android.content.Intent
 import android.os.Bundle
 import android.widget.AdapterView
 import android.widget.ArrayAdapter
 import android.widget.ListView
+import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import com.github.sdp.ratemyepfl.R
-import com.github.sdp.ratemyepfl.model.items.FakeCoursesDatabase
+import com.github.sdp.ratemyepfl.database.FakeCoursesDatabase
+import com.github.sdp.ratemyepfl.viewmodel.CourseListViewModel
 
-class CoursesActivity : AppCompatActivity() {
+class CourseListActivity : AppCompatActivity() {
 
     private lateinit var coursesView: ListView
+    val viewModel by viewModels<CourseListViewModel>()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_courses)
 
-        val fakeDatabase = FakeCoursesDatabase()
-        val courseList = fakeDatabase.getCoursesList()
+        val courseList = viewModel.getCourses()
 
         coursesView = findViewById(R.id.coursesListView)
         val adapter = ArrayAdapter(this, android.R.layout.simple_list_item_1,
@@ -31,8 +33,8 @@ class CoursesActivity : AppCompatActivity() {
     }
 
     private fun displayCourseReviews(courseName: String) {
-        val intent = Intent(this, ReviewsActivity::class.java)
-        intent.putExtra(ReviewsActivity.EXTRA_COURSE_NAME, courseName)
+        val intent = Intent(this, CourseReviewListActivity::class.java)
+        intent.putExtra(CourseReviewListActivity.EXTRA_COURSE_NAME, courseName)
         startActivity(intent)
     }
 }

--- a/app/src/main/java/com/github/sdp/ratemyepfl/activity/course/CourseReviewActivity.kt
+++ b/app/src/main/java/com/github/sdp/ratemyepfl/activity/course/CourseReviewActivity.kt
@@ -1,4 +1,4 @@
-package com.github.sdp.ratemyepfl.activity
+package com.github.sdp.ratemyepfl.activity.course
 
 import android.content.Intent
 import android.os.Bundle
@@ -8,6 +8,7 @@ import android.widget.*
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import com.github.sdp.ratemyepfl.R
+import com.github.sdp.ratemyepfl.activity.CourseMgtActivity
 import com.github.sdp.ratemyepfl.model.items.Course
 import com.github.sdp.ratemyepfl.model.review.CourseReview
 import com.github.sdp.ratemyepfl.model.review.ReviewRating

--- a/app/src/main/java/com/github/sdp/ratemyepfl/activity/course/CourseReviewListActivity.kt
+++ b/app/src/main/java/com/github/sdp/ratemyepfl/activity/course/CourseReviewListActivity.kt
@@ -1,26 +1,28 @@
-package com.github.sdp.ratemyepfl.activity
+package com.github.sdp.ratemyepfl.activity.course
 
 import android.os.Bundle
 import android.widget.ListView
+import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import com.github.sdp.ratemyepfl.R
-import com.github.sdp.ratemyepfl.model.items.FakeCoursesDatabase
+import com.github.sdp.ratemyepfl.database.FakeCoursesDatabase
 import com.github.sdp.ratemyepfl.model.review.CourseReviewAdapter
+import com.github.sdp.ratemyepfl.viewmodel.ReviewListViewModel
 
-class ReviewsActivity : AppCompatActivity() {
+class CourseReviewListActivity : AppCompatActivity() {
 
     companion object {
         const val EXTRA_COURSE_NAME: String = "com.github.sdp.ratemyepfl.activity.course_name"
     }
 
     private lateinit var reviewsView: ListView
+    private val viewModel by viewModels<ReviewListViewModel>()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_reviews)
 
-        val fakeDatabase = FakeCoursesDatabase()
-        val reviewsList = fakeDatabase.getReviewsList()
+        val reviewsList = viewModel.getReviews()
 
         reviewsView = findViewById(R.id.reviewsListView)
         val reviewAdapter = CourseReviewAdapter(this, R.layout.list_reviews_row,

--- a/app/src/main/java/com/github/sdp/ratemyepfl/activity/course/CourseReviewListActivity.kt
+++ b/app/src/main/java/com/github/sdp/ratemyepfl/activity/course/CourseReviewListActivity.kt
@@ -8,7 +8,9 @@ import com.github.sdp.ratemyepfl.R
 import com.github.sdp.ratemyepfl.database.FakeCoursesDatabase
 import com.github.sdp.ratemyepfl.model.review.CourseReviewAdapter
 import com.github.sdp.ratemyepfl.viewmodel.ReviewListViewModel
+import dagger.hilt.android.AndroidEntryPoint
 
+@AndroidEntryPoint
 class CourseReviewListActivity : AppCompatActivity() {
 
     companion object {

--- a/app/src/main/java/com/github/sdp/ratemyepfl/database/CourseDatabase.kt
+++ b/app/src/main/java/com/github/sdp/ratemyepfl/database/CourseDatabase.kt
@@ -4,6 +4,5 @@ import com.github.sdp.ratemyepfl.model.items.Course
 import com.github.sdp.ratemyepfl.model.review.CourseReview
 
 interface CourseDatabase {
-    fun getReviews(): List<CourseReview>
     fun getCourses(): List<Course>
 }

--- a/app/src/main/java/com/github/sdp/ratemyepfl/database/CourseDatabase.kt
+++ b/app/src/main/java/com/github/sdp/ratemyepfl/database/CourseDatabase.kt
@@ -1,0 +1,9 @@
+package com.github.sdp.ratemyepfl.database
+
+import com.github.sdp.ratemyepfl.model.items.Course
+import com.github.sdp.ratemyepfl.model.review.CourseReview
+
+interface CourseDatabase {
+    fun getReviews(): List<CourseReview>
+    fun getCourses(): List<Course>
+}

--- a/app/src/main/java/com/github/sdp/ratemyepfl/database/CourseReviewDatabase.kt
+++ b/app/src/main/java/com/github/sdp/ratemyepfl/database/CourseReviewDatabase.kt
@@ -1,0 +1,7 @@
+package com.github.sdp.ratemyepfl.database
+
+import com.github.sdp.ratemyepfl.model.review.CourseReview
+
+interface CourseReviewDatabase {
+    fun getReviews(): List<CourseReview>
+}

--- a/app/src/main/java/com/github/sdp/ratemyepfl/database/FakeCourseReviewDatabase.kt
+++ b/app/src/main/java/com/github/sdp/ratemyepfl/database/FakeCourseReviewDatabase.kt
@@ -1,0 +1,33 @@
+package com.github.sdp.ratemyepfl.database
+
+import com.github.sdp.ratemyepfl.model.review.CourseReview
+import com.github.sdp.ratemyepfl.model.review.ReviewRating
+import java.time.LocalDate
+import javax.inject.Inject
+
+class FakeCourseReviewDatabase @Inject constructor() : CourseReviewDatabase {
+    override fun getReviews(): List<CourseReview> {
+        return listOf(
+            CourseReview.Builder().setTitle("Absolument dé-men-tiel")
+                .setComment("Regardez moi cet athlète, regardez moi cette plastique.")
+                .setRating(ReviewRating.EXCELLENT)
+                .setDate(LocalDate.now())
+                .build(),
+            CourseReview.Builder().setTitle("SA PARLE CASH")
+                .setComment("Moi je cache rien, ça parle cash ici.")
+                .setRating(ReviewRating.POOR)
+                .setDate(LocalDate.now())
+                .build(),
+            CourseReview.Builder().setTitle("Allez-y, je pense à quel chiffre là ?")
+                .setComment("Pfff n'importe quoi, je pensais à 1000.")
+                .setRating(ReviewRating.TERRIBLE)
+                .setDate(LocalDate.now())
+                .build(),
+            CourseReview.Builder().setTitle("Ce mec ne fait qu'un avec le serpent")
+                .setComment("Regardez comme il ondule. En forêt Amazonienne, je prendrais ce type pour un serpent... Il a tout du reptile !")
+                .setRating(ReviewRating.GOOD)
+                .setDate(LocalDate.now())
+                .build()
+        )
+    }
+}

--- a/app/src/main/java/com/github/sdp/ratemyepfl/database/FakeCoursesDatabase.kt
+++ b/app/src/main/java/com/github/sdp/ratemyepfl/database/FakeCoursesDatabase.kt
@@ -1,11 +1,13 @@
-package com.github.sdp.ratemyepfl.model.items
+package com.github.sdp.ratemyepfl.database
 
+import com.github.sdp.ratemyepfl.model.items.Course
 import com.github.sdp.ratemyepfl.model.review.CourseReview
 import com.github.sdp.ratemyepfl.model.review.ReviewRating
 import java.time.LocalDate
+import javax.inject.Inject
 
-class FakeCoursesDatabase {
-    fun getReviewsList(): List<CourseReview> {
+class FakeCoursesDatabase : CourseDatabase {
+    override fun getReviews(): List<CourseReview> {
         return listOf(
             CourseReview.Builder().setTitle("Absolument dé-men-tiel")
                 .setComment("Regardez moi cet athlète, regardez moi cette plastique.")
@@ -30,7 +32,7 @@ class FakeCoursesDatabase {
         )
     }
 
-    fun getCoursesList(): List<Course> {
+    override fun getCourses(): List<Course> {
         return listOf(
             Course(
                 name="Software development project",

--- a/app/src/main/java/com/github/sdp/ratemyepfl/database/FakeCoursesDatabase.kt
+++ b/app/src/main/java/com/github/sdp/ratemyepfl/database/FakeCoursesDatabase.kt
@@ -6,32 +6,8 @@ import com.github.sdp.ratemyepfl.model.review.ReviewRating
 import java.time.LocalDate
 import javax.inject.Inject
 
-class FakeCoursesDatabase : CourseDatabase {
-    override fun getReviews(): List<CourseReview> {
-        return listOf(
-            CourseReview.Builder().setTitle("Absolument dé-men-tiel")
-                .setComment("Regardez moi cet athlète, regardez moi cette plastique.")
-                .setRating(ReviewRating.EXCELLENT)
-                .setDate(LocalDate.now())
-                .build(),
-            CourseReview.Builder().setTitle("SA PARLE CASH")
-                .setComment("Moi je cache rien, ça parle cash ici.")
-                .setRating(ReviewRating.POOR)
-                .setDate(LocalDate.now())
-                .build(),
-            CourseReview.Builder().setTitle("Allez-y, je pense à quel chiffre là ?")
-                .setComment("Pfff n'importe quoi, je pensais à 1000.")
-                .setRating(ReviewRating.TERRIBLE)
-                .setDate(LocalDate.now())
-                .build(),
-            CourseReview.Builder().setTitle("Ce mec ne fait qu'un avec le serpent")
-                .setComment("Regardez comme il ondule. En forêt Amazonienne, je prendrais ce type pour un serpent... Il a tout du reptile !")
-                .setRating(ReviewRating.GOOD)
-                .setDate(LocalDate.now())
-                .build()
-        )
-    }
 
+class FakeCoursesDatabase @Inject constructor() : CourseDatabase {
     override fun getCourses(): List<Course> {
         return listOf(
             Course(

--- a/app/src/main/java/com/github/sdp/ratemyepfl/dependencyinjection/CourseDatabaseModule.kt
+++ b/app/src/main/java/com/github/sdp/ratemyepfl/dependencyinjection/CourseDatabaseModule.kt
@@ -1,5 +1,6 @@
 package com.github.sdp.ratemyepfl.dependencyinjection
 
+import android.app.Application
 import com.github.sdp.ratemyepfl.database.CourseDatabase
 import com.github.sdp.ratemyepfl.database.FakeCoursesDatabase
 import dagger.Binds
@@ -7,10 +8,12 @@ import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.android.components.ViewComponent
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
 
 @Module
-@InstallIn(ViewComponent::class)
+@InstallIn(SingletonComponent::class)
 abstract class CourseDatabaseModule {
-    @Provides
-    fun providesCourseDatabase(): CourseDatabase = FakeCoursesDatabase()
+    @Binds
+    abstract fun bindsCourseDatabase(db: FakeCoursesDatabase): CourseDatabase
 }

--- a/app/src/main/java/com/github/sdp/ratemyepfl/dependencyinjection/CourseDatabaseModule.kt
+++ b/app/src/main/java/com/github/sdp/ratemyepfl/dependencyinjection/CourseDatabaseModule.kt
@@ -1,0 +1,16 @@
+package com.github.sdp.ratemyepfl.dependencyinjection
+
+import com.github.sdp.ratemyepfl.database.CourseDatabase
+import com.github.sdp.ratemyepfl.database.FakeCoursesDatabase
+import dagger.Binds
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.components.ViewComponent
+
+@Module
+@InstallIn(ViewComponent::class)
+abstract class CourseDatabaseModule {
+    @Provides
+    fun providesCourseDatabase(): CourseDatabase = FakeCoursesDatabase()
+}

--- a/app/src/main/java/com/github/sdp/ratemyepfl/dependencyinjection/CourseReviewDatabaseModule.kt
+++ b/app/src/main/java/com/github/sdp/ratemyepfl/dependencyinjection/CourseReviewDatabaseModule.kt
@@ -1,0 +1,17 @@
+package com.github.sdp.ratemyepfl.dependencyinjection
+
+import com.github.sdp.ratemyepfl.database.CourseReviewDatabase
+import com.github.sdp.ratemyepfl.database.FakeCourseReviewDatabase
+import dagger.Binds
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+
+@Module
+@InstallIn(SingletonComponent::class)
+object CourseReviewDatabaseModule {
+
+    @Provides
+    fun providesCourseReviewDatabase(): CourseReviewDatabase = FakeCourseReviewDatabase()
+}

--- a/app/src/main/java/com/github/sdp/ratemyepfl/model/items/Course.kt
+++ b/app/src/main/java/com/github/sdp/ratemyepfl/model/items/Course.kt
@@ -3,7 +3,7 @@ package com.github.sdp.ratemyepfl.model.items
 import kotlinx.serialization.Serializable
 
 @Serializable
-class Course(
+data class Course(
     val name: String,
     val faculty: String,
     val teacher: String,

--- a/app/src/main/java/com/github/sdp/ratemyepfl/viewmodel/ClassroomsListViewModel.kt
+++ b/app/src/main/java/com/github/sdp/ratemyepfl/viewmodel/ClassroomsListViewModel.kt
@@ -4,8 +4,11 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.ViewModel
 import com.github.sdp.ratemyepfl.model.items.Classroom
 import com.github.sdp.ratemyepfl.placeholder.DataSource
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
 
-class ClassroomsListViewModel(dataSource: DataSource = DataSource()) : ViewModel() {
+@HiltViewModel
+class ClassroomsListViewModel @Inject constructor(dataSource: DataSource) : ViewModel() {
 
     private val roomsLiveData = dataSource.getRoomList()
 

--- a/app/src/main/java/com/github/sdp/ratemyepfl/viewmodel/CourseListViewModel.kt
+++ b/app/src/main/java/com/github/sdp/ratemyepfl/viewmodel/CourseListViewModel.kt
@@ -1,0 +1,18 @@
+package com.github.sdp.ratemyepfl.viewmodel
+
+import androidx.lifecycle.ViewModel
+import com.github.sdp.ratemyepfl.database.CourseDatabase
+import com.github.sdp.ratemyepfl.model.items.Course
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+/**
+ * View model of the courseList activity. Bridge between the activity
+ * and the database
+ * NB: Change the database into repository when implemented
+ */
+@HiltViewModel
+class CourseListViewModel @Inject constructor(val database: CourseDatabase) : ViewModel() {
+
+    fun getCourses(): List<Course> = database.getCourses()
+}

--- a/app/src/main/java/com/github/sdp/ratemyepfl/viewmodel/CourseReviewViewModel.kt
+++ b/app/src/main/java/com/github/sdp/ratemyepfl/viewmodel/CourseReviewViewModel.kt
@@ -23,6 +23,7 @@ import javax.inject.Inject
 class CourseReviewViewModel @Inject constructor(
     private val savedStateHandle: SavedStateHandle
 ) : ViewModel() {
+
     val rating: MutableLiveData<ReviewRating> = MutableLiveData(null)
     val title: MutableLiveData<String> = MutableLiveData(null)
     val comment: MutableLiveData<String> = MutableLiveData(null)

--- a/app/src/main/java/com/github/sdp/ratemyepfl/viewmodel/CourseReviewViewModel.kt
+++ b/app/src/main/java/com/github/sdp/ratemyepfl/viewmodel/CourseReviewViewModel.kt
@@ -3,7 +3,7 @@ package com.github.sdp.ratemyepfl.viewmodel
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
-import com.github.sdp.ratemyepfl.activity.CourseReviewActivity
+import com.github.sdp.ratemyepfl.activity.course.CourseReviewActivity
 import com.github.sdp.ratemyepfl.model.items.Course
 import com.github.sdp.ratemyepfl.model.review.CourseReview
 import com.github.sdp.ratemyepfl.model.review.ReviewRating

--- a/app/src/main/java/com/github/sdp/ratemyepfl/viewmodel/ReviewListViewModel.kt
+++ b/app/src/main/java/com/github/sdp/ratemyepfl/viewmodel/ReviewListViewModel.kt
@@ -2,13 +2,15 @@ package com.github.sdp.ratemyepfl.viewmodel
 
 import androidx.lifecycle.ViewModel
 import com.github.sdp.ratemyepfl.database.CourseDatabase
+import com.github.sdp.ratemyepfl.database.CourseReviewDatabase
 import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
 
 /**
  * TO DO: change the database to repository, when available
  */
 @HiltViewModel
-class ReviewListViewModel(val database: CourseDatabase) : ViewModel() {
+class ReviewListViewModel @Inject constructor(val database: CourseReviewDatabase) : ViewModel() {
 
     fun getReviews() = database.getReviews()
 

--- a/app/src/main/java/com/github/sdp/ratemyepfl/viewmodel/ReviewListViewModel.kt
+++ b/app/src/main/java/com/github/sdp/ratemyepfl/viewmodel/ReviewListViewModel.kt
@@ -1,0 +1,15 @@
+package com.github.sdp.ratemyepfl.viewmodel
+
+import androidx.lifecycle.ViewModel
+import com.github.sdp.ratemyepfl.database.CourseDatabase
+import dagger.hilt.android.lifecycle.HiltViewModel
+
+/**
+ * TO DO: change the database to repository, when available
+ */
+@HiltViewModel
+class ReviewListViewModel(val database: CourseDatabase) : ViewModel() {
+
+    fun getReviews() = database.getReviews()
+
+}

--- a/app/src/main/java/com/github/sdp/ratemyepfl/viewmodel/RoomReviewsListViewModel.kt
+++ b/app/src/main/java/com/github/sdp/ratemyepfl/viewmodel/RoomReviewsListViewModel.kt
@@ -2,12 +2,25 @@ package com.github.sdp.ratemyepfl.viewmodel
 
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
+import com.github.sdp.ratemyepfl.activity.classrooms.ClassroomsListActivity
+import com.github.sdp.ratemyepfl.activity.classrooms.RoomReviewsListActivity
 import com.github.sdp.ratemyepfl.model.review.ClassroomReview
 import com.github.sdp.ratemyepfl.placeholder.DataSource
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedInject
+import dagger.hilt.android.lifecycle.HiltViewModel
 import java.time.LocalDate
+import javax.inject.Inject
 
-class RoomReviewsListViewModel (private val dataSource: DataSource, private val id: String?) : ViewModel() {
+@HiltViewModel
+class RoomReviewsListViewModel @Inject constructor(
+    private val dataSource: DataSource,
+    private val savedStateHandle: SavedStateHandle
+) : ViewModel() {
+
+    val id: String? = savedStateHandle.get<String>(ClassroomsListActivity.EXTRA_ROOM_ID)
 
     // Reviews of the classroom
     private val reviewsLiveData = MutableLiveData(
@@ -29,23 +42,5 @@ class RoomReviewsListViewModel (private val dataSource: DataSource, private val 
             reviewsLiveData.postValue(updatedList)
         }
     }
-
-    /*class RoomReviewsListViewModelFactory(
-        private val dataSource: DataSource,
-        private val id: String?
-    ) :
-        ViewModelProvider.Factory {
-        override fun <T : ViewModel?> create(modelClass: Class<T>): T {
-            if (modelClass.isAssignableFrom(RoomReviewsListViewModel::class.java)) {
-                @Suppress("UNCHECKED_CAST")
-                return RoomReviewsListViewModel(
-                    dataSource = dataSource,
-                    id = id
-                ) as T
-            }
-            throw IllegalArgumentException("Unknown ViewModel class")
-        }
-
-    }*/
 
 }

--- a/app/src/main/res/layout/activity_course_review.xml
+++ b/app/src/main/res/layout/activity_course_review.xml
@@ -4,48 +4,15 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <RadioGroup
-        android:id="@+id/courseReviewRating"
+    <include
+        android:id="@+id/layoutRadioGroupCourseReview"
+        layout="@layout/rating_radio_group"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_margin="20dp"
-        android:layout_marginEnd="20dp"
-        android:orientation="horizontal"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/courseReviewCourseName">
-
-        <RadioButton
-            android:id="@+id/courseRatingTerribleRadioButton"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="@string/rating_value_1" />
-
-        <RadioButton
-            android:id="@+id/courseRatingPoorRadioButton"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="@string/rating_value_2" />
-
-        <RadioButton
-            android:id="@+id/courseRatingAverageRadioButton"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="@string/rating_value_3" />
-
-        <RadioButton
-            android:id="@+id/courseRatingGoodRadioButton"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="@string/rating_value_4" />
-
-        <RadioButton
-            android:id="@+id/courseRatingExcellentRadioButton"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="@string/rating_value_5" />
-
-    </RadioGroup>
+        app:layout_constraintTop_toBottomOf="@+id/courseReviewCourseName" />
 
     <TextView
         android:id="@+id/courseReviewCourseName"
@@ -67,11 +34,13 @@
         style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
         android:layout_width="match_parent"
         android:layout_height="0dp"
-        android:layout_marginStart="24dp"
-        android:layout_marginTop="32dp"
-        android:layout_marginEnd="24dp"
+        android:layout_marginTop="28dp"
+        android:layout_marginBottom="32dp"
+        android:paddingStart="24dp"
+        android:paddingEnd="24dp"
+        app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/courseReviewRating">
+        app:layout_constraintTop_toBottomOf="@+id/layoutRadioGroupCourseReview">
 
         <com.google.android.material.textfield.TextInputEditText
             android:id="@+id/courseReviewTitle"
@@ -84,8 +53,8 @@
         android:id="@+id/courseReviewSubmit"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginBottom="32dp"
         android:layout_marginTop="32dp"
+        android:layout_marginBottom="32dp"
         android:text="Submit your comment"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/rating_radio_group.xml
+++ b/app/src/main/res/layout/rating_radio_group.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    xmlns:android="http://schemas.android.com/apk/res/android">
+    <RadioGroup
+        android:id="@+id/courseReviewRating"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent">
+
+        <RadioButton
+            android:id="@+id/courseRatingTerribleRadioButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/rating_value_1" />
+
+        <RadioButton
+            android:id="@+id/courseRatingPoorRadioButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/rating_value_2" />
+
+        <RadioButton
+            android:id="@+id/courseRatingAverageRadioButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/rating_value_3" />
+
+        <RadioButton
+            android:id="@+id/courseRatingGoodRadioButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/rating_value_4" />
+
+        <RadioButton
+            android:id="@+id/courseRatingExcellentRadioButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/rating_value_5" />
+
+    </RadioGroup>
+</RelativeLayout>


### PR DESCRIPTION
This fix covers two main points. First, it refactors all activities using the MVVM patterns (for those that were not done during the last sprint). Then, it refactors every view model such that no factory is needed for instantiation (only use Hilt dependency injection).