### PR TITLE
Removed the use of serialization and prepared code structure for the review info display

### DIFF
--- a/app/src/androidTest/java/com/github/sdp/ratemyepfl/activity/CourseReviewActivityTest.kt
+++ b/app/src/androidTest/java/com/github/sdp/ratemyepfl/activity/CourseReviewActivityTest.kt
@@ -9,8 +9,6 @@ import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import com.github.sdp.ratemyepfl.R
 import com.github.sdp.ratemyepfl.database.FakeCourseRepository
-import com.github.sdp.ratemyepfl.model.items.Course
-import com.github.sdp.ratemyepfl.model.serializer.ItemSerializer
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import org.junit.After
@@ -21,7 +19,6 @@ import org.junit.Test
 @HiltAndroidTest
 class CourseReviewActivityTest {
     lateinit var scenario: ActivityScenario<ReviewActivity>
-    private var course = Course("Fake", "Fake", "Fake", 0, "Fake")
 
     @get:Rule(order = 0)
     val hiltRule = HiltAndroidRule(this)
@@ -30,7 +27,7 @@ class CourseReviewActivityTest {
     fun setUp() {
         val intent = Intent(ApplicationProvider.getApplicationContext(), ReviewActivity::class.java)
         intent.putExtra(ReviewActivity.EXTRA_LAYOUT_ID, R.layout.activity_course_review)
-        intent.putExtra(ReviewActivity.EXTRA_ITEM_REVIEWED, ItemSerializer.serialize(course))
+        intent.putExtra(ReviewActivity.EXTRA_ITEM_REVIEWED, "Fake id")
         scenario = ActivityScenario.launch(intent)
     }
 
@@ -42,10 +39,9 @@ class CourseReviewActivityTest {
 
     @Test
     fun isIdVisibleOnActivityLaunch() {
-        val fakeCourseId = FakeCourseRepository.COURSE_BY_ID.id
+        val fakeCourse = FakeCourseRepository.COURSE_BY_ID
         onView(withId(R.id.id_course_info))
-            .check(matches(withText(course.toString())))
+            .check(matches(withText(fakeCourse.toString())))
     }
-
 
 }

--- a/app/src/androidTest/java/com/github/sdp/ratemyepfl/activity/RestaurantReviewActivityTest.kt
+++ b/app/src/androidTest/java/com/github/sdp/ratemyepfl/activity/RestaurantReviewActivityTest.kt
@@ -8,8 +8,7 @@ import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import com.github.sdp.ratemyepfl.R
-import com.github.sdp.ratemyepfl.model.items.Restaurant
-import com.github.sdp.ratemyepfl.model.serializer.ItemSerializer
+import com.github.sdp.ratemyepfl.database.FakeRestaurantRepository
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import org.junit.After
@@ -20,7 +19,6 @@ import org.junit.Test
 @HiltAndroidTest
 class RestaurantReviewActivityTest {
     lateinit var scenario: ActivityScenario<ReviewActivity>
-    private val restaurant = Restaurant("Fake")
 
     @get:Rule(order = 0)
     val hiltRule = HiltAndroidRule(this)
@@ -29,7 +27,7 @@ class RestaurantReviewActivityTest {
     fun setUp() {
         val intent = Intent(ApplicationProvider.getApplicationContext(), ReviewActivity::class.java)
         intent.putExtra(ReviewActivity.EXTRA_LAYOUT_ID, R.layout.activity_restaurant_review)
-        intent.putExtra(ReviewActivity.EXTRA_ITEM_REVIEWED, ItemSerializer.serialize(restaurant))
+        intent.putExtra(ReviewActivity.EXTRA_ITEM_REVIEWED, "Fake id")
         scenario = ActivityScenario.launch(intent)
     }
 
@@ -41,8 +39,9 @@ class RestaurantReviewActivityTest {
 
     @Test
     fun isIdVisibleOnActivityLaunch() {
+        val fakeRestaurant = FakeRestaurantRepository.DEFAULT_RESTAURANT
         onView(withId(R.id.id_restaurant_info))
-            .check(matches(ViewMatchers.withText(restaurant.toString())))
+            .check(matches(ViewMatchers.withText(fakeRestaurant.toString())))
     }
 
 

--- a/app/src/androidTest/java/com/github/sdp/ratemyepfl/activity/RoomReviewActivityTest.kt
+++ b/app/src/androidTest/java/com/github/sdp/ratemyepfl/activity/RoomReviewActivityTest.kt
@@ -48,26 +48,4 @@ class RoomReviewActivityTest {
         onView(withId(R.id.id_room_info))
             .check(matches(withText(fakeRoom.toString())))
     }
-
-    /* This tests depends on the Review activity layout, so it doesn't work when launching
-       a fragment in isolation
-     */
-    @Test
-    fun nonNullArgumentsResetsAddReview() {
-        onView(withId(R.id.reviewNavigationView)).perform(CustomViewActions.navigateTo(R.id.addReviewFragment))
-        val comment = "Good"
-        val title = "Good title"
-        onView(withId(R.id.reviewRatingBar)).perform(
-            AddReviewFragmentTest.performSetRating(
-                ReviewRating.GOOD
-            )
-        )
-        onView(withId(R.id.addReviewComment)).perform(ViewActions.typeText(comment))
-        closeSoftKeyboard()
-        onView(withId(R.id.addReviewTitle)).perform(ViewActions.typeText(title))
-        closeSoftKeyboard()
-        onView(withId(R.id.doneButton)).perform(ViewActions.click())
-        onView(withId(R.id.addReviewComment)).check(matches(withText("")))
-        onView(withId(R.id.addReviewTitle)).check(matches(withText("")))
-    }
 }

--- a/app/src/androidTest/java/com/github/sdp/ratemyepfl/activity/RoomReviewActivityTest.kt
+++ b/app/src/androidTest/java/com/github/sdp/ratemyepfl/activity/RoomReviewActivityTest.kt
@@ -10,10 +10,9 @@ import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import com.github.sdp.ratemyepfl.R
+import com.github.sdp.ratemyepfl.database.FakeClassroomRepository
 import com.github.sdp.ratemyepfl.fragment.review.AddReviewFragmentTest
-import com.github.sdp.ratemyepfl.model.items.Classroom
 import com.github.sdp.ratemyepfl.model.review.ReviewRating
-import com.github.sdp.ratemyepfl.model.serializer.ItemSerializer
 import com.github.sdp.ratemyepfl.utils.CustomViewActions
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
@@ -26,7 +25,6 @@ import org.junit.Test
 @HiltAndroidTest
 class RoomReviewActivityTest {
     lateinit var scenario: ActivityScenario<ReviewActivity>
-    private val classroom = Classroom("Fake")
 
     @get:Rule(order = 0)
     val hiltRule = HiltAndroidRule(this)
@@ -35,7 +33,7 @@ class RoomReviewActivityTest {
     fun setUp() {
         val intent = Intent(ApplicationProvider.getApplicationContext(), ReviewActivity::class.java)
         intent.putExtra(ReviewActivity.EXTRA_LAYOUT_ID, R.layout.activity_room_review)
-        intent.putExtra(ReviewActivity.EXTRA_ITEM_REVIEWED, ItemSerializer.serialize(classroom))
+        intent.putExtra(ReviewActivity.EXTRA_ITEM_REVIEWED, "Fake id")
         scenario = ActivityScenario.launch(intent)
     }
 
@@ -46,8 +44,9 @@ class RoomReviewActivityTest {
 
     @Test
     fun isIdVisibleOnActivityLaunch() {
+        val fakeRoom = FakeClassroomRepository.DEFAULT_ROOM
         onView(withId(R.id.id_room_info))
-            .check(matches(withText(classroom.toString())))
+            .check(matches(withText(fakeRoom.toString())))
     }
 
     /* This tests depends on the Review activity layout, so it doesn't work when launching

--- a/app/src/androidTest/java/com/github/sdp/ratemyepfl/database/FakeClassroomRepository.kt
+++ b/app/src/androidTest/java/com/github/sdp/ratemyepfl/database/FakeClassroomRepository.kt
@@ -20,10 +20,12 @@ class FakeClassroomRepository @Inject constructor() : ClassroomRepositoryInterfa
                 id = "ELA 2",
             )
         )
+
+        val DEFAULT_ROOM = Classroom(id = "CM3")
     }
 
 
     override suspend fun getClassrooms(): List<Classroom> = CLASSROOM_LIST
 
-    override suspend fun getRoomById(id: String): Classroom = Classroom(id = "CM3")
+    override suspend fun getRoomById(id: String): Classroom = DEFAULT_ROOM
 }

--- a/app/src/androidTest/java/com/github/sdp/ratemyepfl/database/FakeRestaurantRepository.kt
+++ b/app/src/androidTest/java/com/github/sdp/ratemyepfl/database/FakeRestaurantRepository.kt
@@ -18,5 +18,5 @@ class FakeRestaurantRepository @Inject constructor() : RestaurantRepositoryInter
 
     override suspend fun getRestaurants(): List<Restaurant> = RESTAURANT_LIST
 
-    override suspend fun getRestaurantById(id: String): Restaurant = Restaurant(id = "Roulotte du Soleil")
+    override suspend fun getRestaurantById(id: String): Restaurant = DEFAULT_RESTAURANT
 }

--- a/app/src/androidTest/java/com/github/sdp/ratemyepfl/fragment/review/AddReviewFragmentTest.kt
+++ b/app/src/androidTest/java/com/github/sdp/ratemyepfl/fragment/review/AddReviewFragmentTest.kt
@@ -1,11 +1,16 @@
 package com.github.sdp.ratemyepfl.fragment.review
 
+import android.content.Intent
 import android.view.View
 import android.widget.RatingBar
+import androidx.core.os.bundleOf
+import androidx.test.core.app.ActivityScenario
+import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.Espresso.closeSoftKeyboard
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.UiController
 import androidx.test.espresso.ViewAction
+import androidx.test.espresso.action.ViewActions
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.action.ViewActions.typeText
 import androidx.test.espresso.assertion.ViewAssertions.matches
@@ -13,28 +18,41 @@ import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import com.github.sdp.ratemyepfl.R
+import com.github.sdp.ratemyepfl.activity.ReviewActivity
 import com.github.sdp.ratemyepfl.dependencyinjection.HiltUtils
 import com.github.sdp.ratemyepfl.model.review.ReviewRating
+import com.github.sdp.ratemyepfl.utils.CustomViewActions
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import org.hamcrest.Matcher
+import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 
 @HiltAndroidTest
 class AddReviewFragmentTest {
+    lateinit var scenario: ActivityScenario<ReviewActivity>
 
     @get:Rule(order = 0)
-    val hiltAndroidRule = HiltAndroidRule(this)
+    val hiltRule = HiltAndroidRule(this)
 
     @Before
     fun setUp() {
-        HiltUtils.launchFragmentInHiltContainer<AddReviewFragment> {}
+        val intent = Intent(ApplicationProvider.getApplicationContext(), ReviewActivity::class.java)
+        intent.putExtra(ReviewActivity.EXTRA_LAYOUT_ID, R.layout.activity_room_review) // can be any
+        intent.putExtra(ReviewActivity.EXTRA_ITEM_REVIEWED, "Fake id")
+        scenario = ActivityScenario.launch(intent)
+    }
+
+    @After
+    fun clean() {
+        scenario.close()
     }
 
     @Test
     fun nullGradeNoReset() {
+        onView(withId(R.id.reviewNavigationView)).perform(CustomViewActions.navigateTo(R.id.addReviewFragment))
         val comment = "Good"
         onView(withId(R.id.addReviewComment)).perform(typeText(comment))
         closeSoftKeyboard()
@@ -44,6 +62,7 @@ class AddReviewFragmentTest {
 
     @Test
     fun nullCommentNoReset() {
+        onView(withId(R.id.reviewNavigationView)).perform(CustomViewActions.navigateTo(R.id.addReviewFragment))
         val title = "Good"
         onView(withId(R.id.reviewRatingBar)).perform(click())
         onView(withId(R.id.addReviewTitle)).perform(typeText(title))
@@ -54,12 +73,33 @@ class AddReviewFragmentTest {
 
     @Test
     fun nullTitleNoReset() {
+        onView(withId(R.id.reviewNavigationView)).perform(CustomViewActions.navigateTo(R.id.addReviewFragment))
         val comment = "Good"
         onView(withId(R.id.reviewRatingBar)).perform(performSetRating(ReviewRating.GOOD))
         onView(withId(R.id.addReviewComment)).perform(typeText(comment))
         closeSoftKeyboard()
         onView(withId(R.id.doneButton)).perform(click())
         onView(withId(R.id.addReviewComment)).check(matches(withText(comment)))
+    }
+
+
+    @Test
+    fun nonNullArgumentsResetsAddReview() {
+        onView(withId(R.id.reviewNavigationView)).perform(CustomViewActions.navigateTo(R.id.addReviewFragment))
+        val comment = "Good"
+        val title = "Good title"
+        onView(withId(R.id.reviewRatingBar)).perform(
+            AddReviewFragmentTest.performSetRating(
+                ReviewRating.GOOD
+            )
+        )
+        onView(withId(R.id.addReviewComment)).perform(ViewActions.typeText(comment))
+        closeSoftKeyboard()
+        onView(withId(R.id.addReviewTitle)).perform(ViewActions.typeText(title))
+        closeSoftKeyboard()
+        onView(withId(R.id.doneButton)).perform(ViewActions.click())
+        onView(withId(R.id.addReviewComment)).check(matches(withText("")))
+        onView(withId(R.id.addReviewTitle)).check(matches(withText("")))
     }
 
     companion object {

--- a/app/src/androidTest/java/com/github/sdp/ratemyepfl/fragment/review/ReviewListFragmentTest.kt
+++ b/app/src/androidTest/java/com/github/sdp/ratemyepfl/fragment/review/ReviewListFragmentTest.kt
@@ -1,32 +1,45 @@
 package com.github.sdp.ratemyepfl.fragment.review
 
+import android.content.Intent
+import androidx.test.core.app.ActivityScenario
+import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.swipeDown
 import androidx.test.espresso.assertion.ViewAssertions
 import androidx.test.espresso.matcher.ViewMatchers.*
 import com.github.sdp.ratemyepfl.R
+import com.github.sdp.ratemyepfl.activity.ReviewActivity
 import com.github.sdp.ratemyepfl.database.FakeReviewsRepository
 import com.github.sdp.ratemyepfl.dependencyinjection.HiltUtils
 import com.github.sdp.ratemyepfl.model.review.Review
 import com.github.sdp.ratemyepfl.model.review.ReviewRating
+import com.github.sdp.ratemyepfl.utils.CustomViewActions
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import org.hamcrest.CoreMatchers
+import org.junit.After
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import java.time.LocalDate
 
 @HiltAndroidTest
 class ReviewListFragmentTest {
+    lateinit var scenario: ActivityScenario<ReviewActivity>
 
     @get:Rule(order = 0)
     val hiltAndroidRule = HiltAndroidRule(this)
 
     @Test
     fun listIsVisible() {
-        HiltUtils.launchFragmentInHiltContainer<ReviewListFragment> {}
+        val intent = Intent(ApplicationProvider.getApplicationContext(), ReviewActivity::class.java)
+        intent.putExtra(ReviewActivity.EXTRA_LAYOUT_ID, R.layout.activity_room_review) // can be any
+        intent.putExtra(ReviewActivity.EXTRA_ITEM_REVIEWED, "Fake id")
+        scenario = ActivityScenario.launch(intent)
+        onView(withId(R.id.reviewNavigationView)).perform(CustomViewActions.navigateTo(R.id.reviewListFragment))
         onView(withId(R.id.reviewRecyclerView))
             .check(ViewAssertions.matches(isDisplayed()))
+        scenario.close()
     }
 
     @Test
@@ -39,12 +52,18 @@ class ReviewListFragmentTest {
                 .setDate(LocalDate.now())
                 .build()
         )
-        HiltUtils.launchFragmentInHiltContainer<ReviewListFragment> {}
+        val intent = Intent(ApplicationProvider.getApplicationContext(), ReviewActivity::class.java)
+        intent.putExtra(ReviewActivity.EXTRA_LAYOUT_ID, R.layout.activity_room_review) // can be any
+        intent.putExtra(ReviewActivity.EXTRA_ITEM_REVIEWED, "Fake id")
+        scenario = ActivityScenario.launch(intent)
+        onView(withId(R.id.reviewNavigationView)).perform(CustomViewActions.navigateTo(R.id.reviewListFragment))
+        Thread.sleep(500) // if no wait, the new list is direclty displayed
         FakeReviewsRepository.reviewList = FakeReviewsRepository.fakeList
         onView(withId(R.id.reviewRecyclerView))
             .check(ViewAssertions.matches(hasChildCount(1)))
         onView(withId(R.id.reviewSwipeRefresh)).perform(swipeDown())
         onView(withId(R.id.reviewRecyclerView))
             .check(ViewAssertions.matches(CoreMatchers.not(hasChildCount(1))))
+        scenario.close()
     }
 }

--- a/app/src/main/java/com/github/sdp/ratemyepfl/activity/ReviewableListActivity.kt
+++ b/app/src/main/java/com/github/sdp/ratemyepfl/activity/ReviewableListActivity.kt
@@ -11,8 +11,6 @@ import com.github.sdp.ratemyepfl.R
 import com.github.sdp.ratemyepfl.adapter.ReviewableAdapter
 import com.github.sdp.ratemyepfl.model.items.Reviewable
 import com.github.sdp.ratemyepfl.utils.ListActivityUtils
-import kotlinx.serialization.encodeToString
-import kotlinx.serialization.json.Json
 
 abstract class ReviewableListActivity<T : Reviewable> : AppCompatActivity() {
 
@@ -66,7 +64,7 @@ abstract class ReviewableListActivity<T : Reviewable> : AppCompatActivity() {
      */
     private fun displayReviews(t: T) {
         val intent = Intent(this, ReviewActivity::class.java)
-        intent.putExtra(ReviewActivity.EXTRA_ITEM_REVIEWED, Json.encodeToString<Reviewable>(t))
+        intent.putExtra(ReviewActivity.EXTRA_ITEM_REVIEWED, t.id)
         intent.putExtra(ReviewActivity.EXTRA_LAYOUT_ID, getLayoutId())
         startActivity(intent)
     }

--- a/app/src/main/java/com/github/sdp/ratemyepfl/fragment/review/AddReviewFragment.kt
+++ b/app/src/main/java/com/github/sdp/ratemyepfl/fragment/review/AddReviewFragment.kt
@@ -71,11 +71,7 @@ class AddReviewFragment : Fragment(R.layout.fragment_add_review) {
                 )
         }
 
-        activityViewModel.getReviewable().observe(viewLifecycleOwner) {
-            reviewIndicationTitle.text = getString(R.string.title_review, it?.toString())
-
-        }
-
+        reviewIndicationTitle.text = getString(R.string.title_review, activityViewModel.id)
         setupListeners()
     }
 
@@ -102,7 +98,7 @@ class AddReviewFragment : Fragment(R.layout.fragment_add_review) {
      *  Adds the review to the database
      */
     private fun addReview() {
-        if (viewModel.submitReview(activityViewModel.getReviewable().value)) {
+        if (viewModel.submitReview(activityViewModel.id)) {
             reset()
             // Bar that will appear at the bottom of the screen
             Snackbar.make(requireView(), R.string.review_sent_text, Snackbar.LENGTH_SHORT)

--- a/app/src/main/java/com/github/sdp/ratemyepfl/fragment/review/CourseReviewInfoFragment.kt
+++ b/app/src/main/java/com/github/sdp/ratemyepfl/fragment/review/CourseReviewInfoFragment.kt
@@ -6,7 +6,7 @@ import android.widget.TextView
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import com.github.sdp.ratemyepfl.R
-import com.github.sdp.ratemyepfl.viewmodel.ReviewViewModel
+import com.github.sdp.ratemyepfl.viewmodel.CourseInfoViewModel
 import dagger.hilt.android.AndroidEntryPoint
 
 /*
@@ -16,12 +16,12 @@ Fragment displayed all relevant information for a Course
 class CourseReviewInfoFragment : Fragment(R.layout.fragment_course_review_info) {
 
     // Gets the shared view model
-    private val viewModel by activityViewModels<ReviewViewModel>()
+    private val viewModel by activityViewModels<CourseInfoViewModel>()
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        viewModel.getReviewable().observe(viewLifecycleOwner) { reviewable ->
-            view.findViewById<TextView>(R.id.id_course_info).text = reviewable?.toString()
+        viewModel.course.observe(viewLifecycleOwner) { course ->
+            view.findViewById<TextView>(R.id.id_course_info).text = course?.toString()
         }
     }
 }

--- a/app/src/main/java/com/github/sdp/ratemyepfl/fragment/review/RestaurantReviewInfoFragment.kt
+++ b/app/src/main/java/com/github/sdp/ratemyepfl/fragment/review/RestaurantReviewInfoFragment.kt
@@ -6,7 +6,7 @@ import android.widget.TextView
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import com.github.sdp.ratemyepfl.R
-import com.github.sdp.ratemyepfl.viewmodel.ReviewViewModel
+import com.github.sdp.ratemyepfl.viewmodel.RestaurantInfoViewModel
 import dagger.hilt.android.AndroidEntryPoint
 
 /*
@@ -16,11 +16,11 @@ Fragment displayed all relevant information for a restaurant
 class RestaurantReviewInfoFragment : Fragment(R.layout.fragment_restaurant_review_info) {
 
     // Gets the shared view model
-    private val viewModel by activityViewModels<ReviewViewModel>()
+    private val viewModel by activityViewModels<RestaurantInfoViewModel>()
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        viewModel.getReviewable().observe(viewLifecycleOwner) {
+        viewModel.restaurant.observe(viewLifecycleOwner) {
             view.findViewById<TextView>(R.id.id_restaurant_info).text = it?.toString()
         }
     }

--- a/app/src/main/java/com/github/sdp/ratemyepfl/fragment/review/ReviewListFragment.kt
+++ b/app/src/main/java/com/github/sdp/ratemyepfl/fragment/review/ReviewListFragment.kt
@@ -43,7 +43,7 @@ class ReviewListFragment : Fragment(R.layout.fragment_review_list) {
             swipeRefresher.isRefreshing = false
         }
 
-        viewModel.getReviews().observe(viewLifecycleOwner) {
+        viewModel.reviews.observe(viewLifecycleOwner) {
             it?.let {
                 reviewsAdapter.submitList(it.toMutableList())
             }

--- a/app/src/main/java/com/github/sdp/ratemyepfl/fragment/review/RoomReviewInfoFragment.kt
+++ b/app/src/main/java/com/github/sdp/ratemyepfl/fragment/review/RoomReviewInfoFragment.kt
@@ -6,7 +6,7 @@ import android.widget.TextView
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import com.github.sdp.ratemyepfl.R
-import com.github.sdp.ratemyepfl.viewmodel.ReviewViewModel
+import com.github.sdp.ratemyepfl.viewmodel.ClassroomInfoViewModel
 import dagger.hilt.android.AndroidEntryPoint
 
 /*
@@ -16,11 +16,11 @@ Fragment displayed all relevant information for a Classroom
 class RoomReviewInfoFragment : Fragment(R.layout.fragment_room_review_info) {
 
     // Gets the shared view model
-    private val viewModel by activityViewModels<ReviewViewModel>()
+    private val viewModel by activityViewModels<ClassroomInfoViewModel>()
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        viewModel.getReviewable().observe(viewLifecycleOwner) {
+        viewModel.room.observe(viewLifecycleOwner) {
             view.findViewById<TextView>(R.id.id_room_info).text = it?.toString()
         }
     }

--- a/app/src/main/java/com/github/sdp/ratemyepfl/viewmodel/AddReviewViewModel.kt
+++ b/app/src/main/java/com/github/sdp/ratemyepfl/viewmodel/AddReviewViewModel.kt
@@ -3,7 +3,6 @@ package com.github.sdp.ratemyepfl.viewmodel
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import com.github.sdp.ratemyepfl.database.ReviewsRepository
-import com.github.sdp.ratemyepfl.model.items.Reviewable
 import com.github.sdp.ratemyepfl.model.review.Review
 import com.github.sdp.ratemyepfl.model.review.ReviewRating
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -52,7 +51,7 @@ class AddReviewViewModel @Inject constructor(
      *
      * @return true if it succeeds to build the review, false otherwise
      */
-    fun submitReview(item: Reviewable?): Boolean {
+    fun submitReview(id: String): Boolean {
         val rating = rating.value
         val comment = comment.value
         val title = title.value
@@ -60,13 +59,13 @@ class AddReviewViewModel @Inject constructor(
 
         if (comment == null || comment == "") return false
         if (title == null || title == "") return false
-        if (rating == null || item == null) return false
+        if (rating == null) return false
 
         val review = Review.Builder()
             .setRating(rating)
             .setTitle(title)
             .setComment(comment)
-            .setReviewableID(item.id)
+            .setReviewableID(id)
             .setDate(date)
             .build()
         reviewRepo.add(review)

--- a/app/src/main/java/com/github/sdp/ratemyepfl/viewmodel/ClassroomInfoViewModel.kt
+++ b/app/src/main/java/com/github/sdp/ratemyepfl/viewmodel/ClassroomInfoViewModel.kt
@@ -1,0 +1,32 @@
+package com.github.sdp.ratemyepfl.viewmodel
+
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.viewModelScope
+import com.github.sdp.ratemyepfl.database.ClassroomRepositoryInterface
+import com.github.sdp.ratemyepfl.database.ReviewsRepository
+import com.github.sdp.ratemyepfl.model.items.Classroom
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class ClassroomInfoViewModel @Inject constructor(
+    private val reviewRepo: ReviewsRepository,
+    private val roomRepo: ClassroomRepositoryInterface,
+    private val savedStateHandle: SavedStateHandle
+) : ReviewViewModel(
+    reviewRepo, savedStateHandle
+) {
+    val room = MutableLiveData<Classroom>()
+
+    init {
+        updateRoom()
+    }
+
+    fun updateRoom() {
+        viewModelScope.launch {
+            room.postValue(roomRepo.getRoomById(id))
+        }
+    }
+}

--- a/app/src/main/java/com/github/sdp/ratemyepfl/viewmodel/CourseInfoViewModel.kt
+++ b/app/src/main/java/com/github/sdp/ratemyepfl/viewmodel/CourseInfoViewModel.kt
@@ -1,0 +1,32 @@
+package com.github.sdp.ratemyepfl.viewmodel
+
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.viewModelScope
+import com.github.sdp.ratemyepfl.database.CourseRepositoryInterface
+import com.github.sdp.ratemyepfl.database.ReviewsRepository
+import com.github.sdp.ratemyepfl.model.items.Course
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class CourseInfoViewModel @Inject constructor(
+    private val reviewRepo: ReviewsRepository,
+    private val courseRepo: CourseRepositoryInterface,
+    private val savedStateHandle: SavedStateHandle
+) : ReviewViewModel(
+    reviewRepo, savedStateHandle
+) {
+    val course = MutableLiveData<Course>()
+
+    init {
+        updateCourse()
+    }
+
+    fun updateCourse() {
+        viewModelScope.launch {
+            course.postValue(courseRepo.getCourseById(id))
+        }
+    }
+}

--- a/app/src/main/java/com/github/sdp/ratemyepfl/viewmodel/RestaurantInfoViewModel.kt
+++ b/app/src/main/java/com/github/sdp/ratemyepfl/viewmodel/RestaurantInfoViewModel.kt
@@ -1,0 +1,32 @@
+package com.github.sdp.ratemyepfl.viewmodel
+
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.viewModelScope
+import com.github.sdp.ratemyepfl.database.RestaurantRepositoryInterface
+import com.github.sdp.ratemyepfl.database.ReviewsRepository
+import com.github.sdp.ratemyepfl.model.items.Restaurant
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class RestaurantInfoViewModel @Inject constructor(
+    private val reviewRepo: ReviewsRepository,
+    private val restaurantRepo: RestaurantRepositoryInterface,
+    private val savedStateHandle: SavedStateHandle
+) : ReviewViewModel(
+    reviewRepo, savedStateHandle
+) {
+    val restaurant = MutableLiveData<Restaurant>()
+
+    init {
+        updateRestaurant()
+    }
+
+    fun updateRestaurant() {
+        viewModelScope.launch {
+            restaurant.postValue(restaurantRepo.getRestaurantById(id))
+        }
+    }
+}

--- a/app/src/main/java/com/github/sdp/ratemyepfl/viewmodel/ReviewViewModel.kt
+++ b/app/src/main/java/com/github/sdp/ratemyepfl/viewmodel/ReviewViewModel.kt
@@ -26,7 +26,7 @@ open class ReviewViewModel @Inject constructor(
         savedStateHandle.get<String>(ReviewActivity.EXTRA_ITEM_REVIEWED)!!
 
     // Reviews
-    private val reviewsLiveData = MutableLiveData<List<Review>>()
+    val reviews = MutableLiveData<List<Review>>()
 
     val numReviews : LiveData<Int> = computeNumReviews()
 
@@ -38,7 +38,7 @@ open class ReviewViewModel @Inject constructor(
 
     fun updateReviewsList() {
         viewModelScope.launch {
-            reviewsLiveData.postValue(reviewRepo.getByReviewableId(id))
+            reviews.postValue(reviewRepo.getByReviewableId(id))
         }
     }
 
@@ -48,7 +48,7 @@ open class ReviewViewModel @Inject constructor(
      */
     private fun computeNumReviews(): LiveData<Int> {
         return Transformations.switchMap(
-            reviewsLiveData
+            reviews
         ) { reviewList ->
             MutableLiveData(reviewList.size)
         }
@@ -60,18 +60,11 @@ open class ReviewViewModel @Inject constructor(
      */
     private fun computeOverallGrade(): LiveData<Int> {
         return Transformations.switchMap(
-            reviewsLiveData
+            reviews
         ) { reviewList ->
             if(reviewList.isEmpty()) MutableLiveData(NO_GRADE)
             val sumOfRates = reviewList.sumOf { it.rating.toValue() }
             MutableLiveData(sumOfRates / reviewList.size)
         }
-    }
-
-    /**
-     * Returns the list of review as LiveData
-     */
-    fun getReviews(): LiveData<List<Review>> {
-        return reviewsLiveData
     }
 }

--- a/app/src/main/java/com/github/sdp/ratemyepfl/viewmodel/ReviewViewModel.kt
+++ b/app/src/main/java/com/github/sdp/ratemyepfl/viewmodel/ReviewViewModel.kt
@@ -3,12 +3,9 @@ package com.github.sdp.ratemyepfl.viewmodel
 import androidx.lifecycle.*
 import com.github.sdp.ratemyepfl.activity.ReviewActivity
 import com.github.sdp.ratemyepfl.database.ReviewsRepository
-import com.github.sdp.ratemyepfl.model.items.Reviewable
 import com.github.sdp.ratemyepfl.model.review.Review
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
-import kotlinx.serialization.decodeFromString
-import kotlinx.serialization.json.Json
 import javax.inject.Inject
 
 /**
@@ -20,18 +17,12 @@ open class ReviewViewModel @Inject constructor(
     private val savedStateHandle: SavedStateHandle
 ) : ViewModel() {
 
-    private val reviewableExtra: String? =
-        savedStateHandle.get<String>(ReviewActivity.EXTRA_ITEM_REVIEWED)
+    // Id
+    val id: String =
+        savedStateHandle.get<String>(ReviewActivity.EXTRA_ITEM_REVIEWED)!!
 
     // Reviews
     private val reviewsLiveData = MutableLiveData<List<Review>>()
-
-    // Reviewable
-    private val reviewable = MutableLiveData(reviewableExtra?.let { serialized ->
-        Json.decodeFromString<Reviewable>(serialized)
-    })
-
-    val id = reviewable.value?.id
 
     init {
         updateReviewsList()
@@ -73,12 +64,5 @@ open class ReviewViewModel @Inject constructor(
      */
     fun getReviews(): LiveData<List<Review>> {
         return reviewsLiveData
-    }
-
-    /**
-     * Returns the current reviewed item as LiveData
-     */
-    fun getReviewable(): LiveData<Reviewable?> {
-        return reviewable
     }
 }

--- a/app/src/main/java/com/github/sdp/ratemyepfl/viewmodel/ReviewViewModel.kt
+++ b/app/src/main/java/com/github/sdp/ratemyepfl/viewmodel/ReviewViewModel.kt
@@ -17,12 +17,20 @@ open class ReviewViewModel @Inject constructor(
     private val savedStateHandle: SavedStateHandle
 ) : ViewModel() {
 
+    companion object{
+        const val NO_GRADE = 10
+    }
+
     // Id
     val id: String =
         savedStateHandle.get<String>(ReviewActivity.EXTRA_ITEM_REVIEWED)!!
 
     // Reviews
     private val reviewsLiveData = MutableLiveData<List<Review>>()
+
+    val numReviews : LiveData<Int> = computeNumReviews()
+
+    val overallGrade : LiveData<Int> = computeOverallGrade()
 
     init {
         updateReviewsList()
@@ -38,7 +46,7 @@ open class ReviewViewModel @Inject constructor(
     /**
      * Returns the numbers of reviews of the current reviewed item as LiveData
      */
-    fun getNumReviews(): LiveData<Int> {
+    private fun computeNumReviews(): LiveData<Int> {
         return Transformations.switchMap(
             reviewsLiveData
         ) { reviewList ->
@@ -50,11 +58,12 @@ open class ReviewViewModel @Inject constructor(
      * Returns the overall grade of the current reviewed item as LiveData
      * (Note that, for concurrency issues, we calculate the overall grade using the list of reviews)
      */
-    fun getOverallGrade(): LiveData<Int> {
+    private fun computeOverallGrade(): LiveData<Int> {
         return Transformations.switchMap(
             reviewsLiveData
         ) { reviewList ->
-            val sumOfRates = reviewList.map { it.rating.toValue() }.sum()
+            if(reviewList.isEmpty()) MutableLiveData(NO_GRADE)
+            val sumOfRates = reviewList.sumOf { it.rating.toValue() }
             MutableLiveData(sumOfRates / reviewList.size)
         }
     }


### PR DESCRIPTION
In this PR, I changed the structure of the view models for review. Now we don't use serialization anymore. I didn't delete any class or annotation related to serialization to avoid conflicts. But removing it won't have any impact on the app.

Again this work was mostly done together, so the review will be really fast.