### PR TITLE
Fix/change query failure

### DIFF
--- a/app/src/androidTest/java/com/github/sdp/ratemyepfl/database/EventRepositoryTest.kt
+++ b/app/src/androidTest/java/com/github/sdp/ratemyepfl/database/EventRepositoryTest.kt
@@ -12,6 +12,7 @@ import com.google.firebase.firestore.ktx.getField
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.tasks.await
 import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -29,7 +30,7 @@ import javax.inject.Inject
 class EventRepositoryTest {
     private val testEvent = Event(
         "Fake id", 0, 0.0, 0,
-        0, 0.0, 0.0, LocalDateTime.now()
+        0, 0.0, 0.0, LocalDateTime.of(2022, 2, 1, 0, 0)
     )
 
     @get:Rule
@@ -39,9 +40,9 @@ class EventRepositoryTest {
     lateinit var eventRepo: EventRepositoryImpl
 
     @Before
-    fun setup() {
+    fun setup() = runTest {
         hiltRule.inject()
-        eventRepo.add(testEvent)
+        eventRepo.add(testEvent).await()
     }
 
     @After

--- a/app/src/androidTest/java/com/github/sdp/ratemyepfl/database/UserRepositoryTest.kt
+++ b/app/src/androidTest/java/com/github/sdp/ratemyepfl/database/UserRepositoryTest.kt
@@ -98,7 +98,7 @@ class UserRepositoryTest {
             userRepo.getUserByEmail(testUser.email!!)
                 .collect {
                     when (it) {
-                        is QueryState.Failure -> throw Exception(it.errorMessage)
+                        is QueryState.Failure -> throw Exception(it.error)
                         is QueryState.Loading -> {}
                         is QueryState.Success -> {
                             val user = it.data

--- a/app/src/androidTest/java/com/github/sdp/ratemyepfl/database/UserRepositoryTest.kt
+++ b/app/src/androidTest/java/com/github/sdp/ratemyepfl/database/UserRepositoryTest.kt
@@ -117,19 +117,11 @@ class UserRepositoryTest {
     fun registerWorks() = runTest {
         repository.remove("register").await()
         val user = User("register", "reg", "reg")
-        userRepo.register(user)
-            .collect {
-                if (it is QueryState.Success)
-                    assertEquals(false, it.data)
-            }
+        assertEquals(false, userRepo.register(user).await())
 
         assertEquals(true, userRepo.getUserByUid("register") != null)
 
-        userRepo.register(user)
-            .collect {
-                if (it is QueryState.Success)
-                    assertEquals(true, it.data)
-            }
+        assertEquals(true, userRepo.register(user).await())
 
         assertEquals(true, userRepo.getUserByUid("register") != null)
     }

--- a/app/src/androidTest/java/com/github/sdp/ratemyepfl/database/fakes/FakeUserRepository.kt
+++ b/app/src/androidTest/java/com/github/sdp/ratemyepfl/database/fakes/FakeUserRepository.kt
@@ -5,6 +5,7 @@ import com.github.sdp.ratemyepfl.database.query.QueryResult
 import com.github.sdp.ratemyepfl.model.items.Class
 import com.github.sdp.ratemyepfl.model.user.User
 import com.google.android.gms.tasks.Task
+import com.google.android.gms.tasks.Tasks
 import com.google.firebase.firestore.Transaction
 import org.mockito.Mockito
 import javax.inject.Inject
@@ -59,8 +60,6 @@ class FakeUserRepository @Inject constructor() : UserRepository {
     }
 
     @Suppress("UNCHECKED_CAST")
-    override suspend fun register(user: User): QueryResult<Boolean> {
-        return QueryResult.success(true)
-    }
+    override suspend fun register(user: User): Task<Boolean> = Tasks.forResult(true)
 
 }

--- a/app/src/androidTest/java/com/github/sdp/ratemyepfl/database/query/QueryResultTest.kt
+++ b/app/src/androidTest/java/com/github/sdp/ratemyepfl/database/query/QueryResultTest.kt
@@ -19,7 +19,7 @@ class QueryResultTest {
         QueryResult.success(listOf<Int>(1, 2, 3))
 
     private val success = QueryResult.success(1)
-    private val failure = QueryResult.failure<Int>("Failed")
+    private val failure = QueryResult.failure<Int>(Exception("Failed"))
 
     @Test
     fun mapResultWorksForLoading() = runTest {
@@ -37,7 +37,7 @@ class QueryResultTest {
         failure.mapResult { it.toString() }
             .collect {
                 when (it) {
-                    is QueryState.Failure<String> -> assertEquals("Failed", it.errorMessage)
+                    is QueryState.Failure<String> -> assertEquals(failure, it.error)
                     else -> throw Exception("Should be failure")
                 }
             }

--- a/app/src/androidTest/java/com/github/sdp/ratemyepfl/database/query/QueryResultTest.kt
+++ b/app/src/androidTest/java/com/github/sdp/ratemyepfl/database/query/QueryResultTest.kt
@@ -86,16 +86,21 @@ class QueryResultTest {
     @Test
     fun builderConstructorEmitsTheDefaultLoadingInTheBeginning() = runTest {
         var x = 0
+        var loading = false
         QueryResult {
             emit(QueryState.success(0))
         }.collect {
             when (it) {
                 is QueryState.Failure -> x = 2
-                is QueryState.Loading -> assertEquals(0, x)
+                is QueryState.Loading -> {
+                    loading = true
+                    assertEquals(0, x)
+                }
                 is QueryState.Success -> x = 1
             }
         }
 
+        assertEquals(true, loading)
     }
 
     @Test

--- a/app/src/androidTest/java/com/github/sdp/ratemyepfl/database/query/QueryStateTest.kt
+++ b/app/src/androidTest/java/com/github/sdp/ratemyepfl/database/query/QueryStateTest.kt
@@ -7,7 +7,7 @@ class QueryStateTest {
 
     private val success = QueryState.success(1)
     private val loading = QueryState.loading<Int>()
-    private val failure = QueryState.failure<Int>("error")
+    private val failure = QueryState.failure<Int>(Exception("error"))
 
     @Test
     fun mapSuccess() {
@@ -21,6 +21,6 @@ class QueryStateTest {
 
     @Test
     fun mapFailure() {
-        assertEquals(QueryState.failure<String>("error"), failure.map { it.toString() })
+        assertEquals(failure, failure.map { it.toString() })
     }
 }

--- a/app/src/androidTest/java/com/github/sdp/ratemyepfl/database/query/QueryStateTest.kt
+++ b/app/src/androidTest/java/com/github/sdp/ratemyepfl/database/query/QueryStateTest.kt
@@ -1,7 +1,9 @@
 package com.github.sdp.ratemyepfl.database.query
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
 import org.junit.Test
+import java.lang.RuntimeException
 
 class QueryStateTest {
 
@@ -22,5 +24,25 @@ class QueryStateTest {
     @Test
     fun mapFailure() {
         assertEquals(failure, failure.map { it.toString() })
+    }
+
+    @Test
+    fun mapErrorForFailure() {
+        val error = RuntimeException("failed")
+        val runtime = QueryState.failure<Int>(error)
+        assertEquals(runtime, failure.mapError { error })
+    }
+
+    @Test
+    fun mapErrorForFailurePreservesTheType() {
+        val error = RuntimeException("failed")
+        assertEquals(true, (failure.mapError { error }) is QueryState.Failure<Int>)
+    }
+
+    @Test
+    fun mapErrorForFailurePreservesTheState() {
+        val error = RuntimeException("failed")
+        assertEquals(success, success.mapError { error })
+        assertEquals(loading, loading.mapError { error })
     }
 }

--- a/app/src/androidTest/java/com/github/sdp/ratemyepfl/database/query/QueryTest.kt
+++ b/app/src/androidTest/java/com/github/sdp/ratemyepfl/database/query/QueryTest.kt
@@ -1,5 +1,6 @@
 package com.github.sdp.ratemyepfl.database.query
 
+import com.github.sdp.ratemyepfl.database.DatabaseException
 import com.github.sdp.ratemyepfl.database.query.QueryResult.Companion.mapEach
 import com.github.sdp.ratemyepfl.database.util.ArrayItem
 import com.github.sdp.ratemyepfl.database.util.ArrayItem.Companion.toArrayItem
@@ -254,4 +255,14 @@ class QueryTest {
             }
     }
 
+    @Test
+    fun executeFailingCodeReturnsDatabaseException() = runTest {
+        query.whereEqualTo("someNonExistingField", "someNonValidValid")
+            .execute()
+            .collect {
+                when (it) {
+                    is QueryState.Failure -> assertEquals(true, it.error is DatabaseException)
+                }
+            }
+    }
 }

--- a/app/src/main/java/com/github/sdp/ratemyepfl/activity/SplashScreen.kt
+++ b/app/src/main/java/com/github/sdp/ratemyepfl/activity/SplashScreen.kt
@@ -54,11 +54,7 @@ class SplashScreen : AppCompatActivity() {
         if (user.isLoggedIn()) {
             runBlocking {
                 launch(Dispatchers.IO) {
-                    repository.register(User(user)).collect {
-                        when (it) {
-                            is QueryState.Failure -> throw DatabaseException("Fail to register the user $user")
-                        }
-                    }
+                    repository.register(User(user)).await()
                 }
             }
             goToMain()

--- a/app/src/main/java/com/github/sdp/ratemyepfl/database/UserRepository.kt
+++ b/app/src/main/java/com/github/sdp/ratemyepfl/database/UserRepository.kt
@@ -25,6 +25,6 @@ interface UserRepository {
      * @param user: the user to register
      *
      */
-    suspend fun register(user: User): QueryResult<Boolean>
+    suspend fun register(user: User): Task<Boolean>
 
 }

--- a/app/src/main/java/com/github/sdp/ratemyepfl/database/UserRepositoryImpl.kt
+++ b/app/src/main/java/com/github/sdp/ratemyepfl/database/UserRepositoryImpl.kt
@@ -86,11 +86,11 @@ class UserRepositoryImpl(private val repository: Repository<User>) : UserReposit
     override fun getUserByEmail(email: String): QueryResult<User> = getBy(EMAIL_FIELD_NAME, email)
         .map {
             when (it) {
-                is QueryState.Failure -> QueryState.failure<User>(it.errorMessage)
-                is QueryState.Loading -> QueryState.loading<User>()
+                is QueryState.Failure -> QueryState.failure(it.error)
+                is QueryState.Loading -> QueryState.loading()
                 is QueryState.Success -> if (it.data.isEmpty())
-                    QueryState.failure<User>("Unable to find a user with email $email")
-                else QueryState.success<User>(it.data.first())
+                    QueryState.failure(DatabaseException("Unable to find a user with email $email"))
+                else QueryState.success(it.data.first())
             }
         }.asQueryResult()
 

--- a/app/src/main/java/com/github/sdp/ratemyepfl/database/UserRepositoryImpl.kt
+++ b/app/src/main/java/com/github/sdp/ratemyepfl/database/UserRepositoryImpl.kt
@@ -100,7 +100,6 @@ class UserRepositoryImpl(private val repository: Repository<User>) : UserReposit
 
     override suspend fun register(user: User): QueryResult<Boolean> =
         QueryResult {
-            emit(QueryState.loading<Boolean>())
             if (getUserByUid(user.getId()) == null) {
                 repository.add(user).await()
                 emit(QueryState.success(false))

--- a/app/src/main/java/com/github/sdp/ratemyepfl/database/UserRepositoryImpl.kt
+++ b/app/src/main/java/com/github/sdp/ratemyepfl/database/UserRepositoryImpl.kt
@@ -7,12 +7,12 @@ import com.github.sdp.ratemyepfl.database.query.QueryState
 import com.github.sdp.ratemyepfl.model.items.Class
 import com.github.sdp.ratemyepfl.model.user.User
 import com.google.android.gms.tasks.Task
+import com.google.android.gms.tasks.Tasks
 import com.google.firebase.firestore.DocumentSnapshot
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.Transaction
 import com.google.gson.Gson
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.tasks.await
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -98,14 +98,12 @@ class UserRepositoryImpl(private val repository: Repository<User>) : UserReposit
         return repository.update(id, transform)
     }
 
-    override suspend fun register(user: User): QueryResult<Boolean> =
-        QueryResult {
-            if (getUserByUid(user.getId()) == null) {
-                repository.add(user).await()
-                emit(QueryState.success(false))
-            } else {
-                emit(QueryState.success(true))
-            }
+    override suspend fun register(user: User): Task<Boolean> =
+        if (getUserByUid(user.getId()) == null) {
+            repository.add(user).continueWith { false }
+        } else {
+            Tasks.forResult(true)
         }
+
 
 }

--- a/app/src/main/java/com/github/sdp/ratemyepfl/database/query/Query.kt
+++ b/app/src/main/java/com/github/sdp/ratemyepfl/database/query/Query.kt
@@ -170,8 +170,8 @@ data class Query(private val query: FirebaseQuery) {
                 .await()
 
             emit(QueryState.success(result))
-        }.catch {
-            emit(QueryState.failure("Failed to execute the query ${toString()}"))
+        }.catch { error ->
+            emit(QueryState.failure(error))
         }.asQueryResult()
 
     /**

--- a/app/src/main/java/com/github/sdp/ratemyepfl/database/query/QueryResult.kt
+++ b/app/src/main/java/com/github/sdp/ratemyepfl/database/query/QueryResult.kt
@@ -87,6 +87,7 @@ class QueryResult<T>(private val result: Flow<QueryState<T>>) : Flow<QueryState<
     @OptIn(ExperimentalTypeInference::class)
     constructor(@BuilderInference block: suspend FlowCollector<QueryState<T>>.() -> Unit) : this(
         flow {
+            emit(QueryState.loading())
             this.block()
         }.catch { cause ->
             emit(QueryState.failure(cause))

--- a/app/src/main/java/com/github/sdp/ratemyepfl/database/query/QueryResult.kt
+++ b/app/src/main/java/com/github/sdp/ratemyepfl/database/query/QueryResult.kt
@@ -2,7 +2,6 @@ package com.github.sdp.ratemyepfl.database.query
 
 import com.google.firebase.firestore.DocumentSnapshot
 import com.google.firebase.firestore.QuerySnapshot
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.FlowCollector
 import kotlinx.coroutines.flow.flow
@@ -46,7 +45,8 @@ class QueryResult<T>(private val result: Flow<QueryState<T>>) : Flow<QueryState<
      * flow { ... }.asQueryResult()
      * ```
      */
-    constructor(block: suspend FlowCollector<QueryState<T>>.() -> Unit) : this(flow { this.block() })
+    @OptIn(ExperimentalTypeInference::class)
+    constructor(@BuilderInference block: suspend FlowCollector<QueryState<T>>.() -> Unit) : this(flow { this.block() })
 
     companion object {
         /**
@@ -95,11 +95,11 @@ class QueryResult<T>(private val result: Flow<QueryState<T>>) : Flow<QueryState<
          * Create a [QueryResult] that fails immediately. Must only be used for synchronous
          * operation.
          *
-         * @param errorMessage: the error message held by the [QueryResult]
+         * @param error: the error message held by the [QueryResult]
          */
-        fun <T> failure(errorMessage: String): QueryResult<T> =
+        fun <T> failure(error: Throwable): QueryResult<T> =
             flow<QueryState<T>> {
-                emit(QueryState.failure(errorMessage))
+                emit(QueryState.failure(error))
             }.asQueryResult()
     }
 }

--- a/app/src/main/java/com/github/sdp/ratemyepfl/database/query/QueryState.kt
+++ b/app/src/main/java/com/github/sdp/ratemyepfl/database/query/QueryState.kt
@@ -14,12 +14,12 @@ sealed class QueryState<T> {
     data class Success<T>(val data: T) : QueryState<T>()
 
     /** A terminated failed query that holds an error message */
-    data class Failure<T>(val errorMessage: String) : QueryState<T>()
+    data class Failure<T>(val error: Throwable) : QueryState<T>()
 
     companion object {
         fun <T> loading() = Loading<T>()
         fun <T> success(data: T) = Success(data)
-        fun <T> failure(error: String) = Failure<T>(error)
+        fun <T> failure(error: Throwable) = Failure<T>(error)
     }
 
     /**
@@ -31,7 +31,7 @@ sealed class QueryState<T> {
      */
     fun <U> map(op: (T) -> U): QueryState<U> = when (this) {
         is Failure ->
-            failure(this.errorMessage)
+            failure(this.error)
         is Loading ->
             loading()
         is Success ->
@@ -45,7 +45,7 @@ sealed class QueryState<T> {
      */
     fun <U> flatMap(op: (T) -> QueryState<U>): QueryState<U> = when (this) {
         is Failure ->
-            failure(this.errorMessage)
+            failure(this.error)
         is Loading ->
             loading()
         is Success -> op(this.data)

--- a/app/src/main/java/com/github/sdp/ratemyepfl/database/query/QueryState.kt
+++ b/app/src/main/java/com/github/sdp/ratemyepfl/database/query/QueryState.kt
@@ -39,6 +39,17 @@ sealed class QueryState<T> {
     }
 
     /**
+     * Map the error contained by the [Failure] with the provided operation.
+     *
+     * @param op: operation to apply on the content of the [Failure]
+     */
+    fun mapError(op: (Throwable) -> Throwable): QueryState<T> = when (this) {
+        is Failure ->
+            failure(op(this.error))
+        else -> this
+    }
+
+    /**
      * Map the data and flatten it.
      *
      * @param op: operation that mapped the data to a [QueryState]

--- a/app/src/test/java/com/github/sdp/ratemyepfl/database/QueryStateTest.kt
+++ b/app/src/test/java/com/github/sdp/ratemyepfl/database/QueryStateTest.kt
@@ -19,15 +19,15 @@ class QueryStateTest {
 
     @Test
     fun mapWorksForFailure() {
-        val error = "Failed"
+        val error = Exception("Failed")
         val state = QueryState.Failure<Int>(error)
-        assertEquals(error, (state.map { it.toString() } as QueryState.Failure).errorMessage)
+        assertEquals(error, (state.map { it.toString() } as QueryState.Failure).error)
     }
 
     @Test
     fun mapPreservesTheState() {
         val data = 32
-        val error = "error"
+        val error = Exception("error")
 
         val state1 = QueryState.Loading<Int>()
         val state2 = QueryState.success(data)


### PR DESCRIPTION
Change the content of QueryState.Failure to Throwable instead of String. The idea is that we may want to keep some information about the failure, and not only the error message (e.g., perform some specific operation depending on the type of received error)