### PR TITLE
Fix/event concurrency

### DIFF
--- a/app/src/androidTest/java/com/github/sdp/ratemyepfl/database/EventRepositoryTest.kt
+++ b/app/src/androidTest/java/com/github/sdp/ratemyepfl/database/EventRepositoryTest.kt
@@ -12,6 +12,7 @@ import com.google.firebase.firestore.ktx.getField
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.tasks.await
 import kotlinx.coroutines.test.runTest
 import org.junit.After
@@ -80,14 +81,18 @@ class EventRepositoryTest {
     @Test
     fun changeNumParticipantsWorks() {
         runTest {
-            eventRepo.updateParticipants(testEvent.name, USER_ID)
+            launch {
+                eventRepo.updateParticipants(testEvent.name, USER_ID)
+            }.join()
             var event = eventRepo.getEventById(testEvent.name)
             assertNotNull(event)
             assertEquals(testEvent.name, event!!.name)
             assertEquals(1, event.numParticipants)
             assert(event.participants.contains(USER_ID))
 
-            eventRepo.updateParticipants(testEvent.name, USER_ID)
+            launch {
+                eventRepo.updateParticipants(testEvent.name, USER_ID)
+            }.join()
             event = eventRepo.getEventById(testEvent.name)
             assertNotNull(event)
             assertEquals(testEvent.name, event!!.name)

--- a/app/src/androidTest/java/com/github/sdp/ratemyepfl/database/EventRepositoryTest.kt
+++ b/app/src/androidTest/java/com/github/sdp/ratemyepfl/database/EventRepositoryTest.kt
@@ -32,7 +32,7 @@ class EventRepositoryTest {
     private val USER_ID = "Kevin du 13"
     private val testEvent = Event(
         "Fake id", 0, 0.0, 0,
-        0, listOf(), 0.0, 0.0, LocalDateTime.now()
+        1, listOf(), 0.0, 0.0, LocalDateTime.now()
     )
 
     @get:Rule
@@ -81,18 +81,14 @@ class EventRepositoryTest {
     @Test
     fun changeNumParticipantsWorks() {
         runTest {
-            launch {
-                eventRepo.updateParticipants(testEvent.name, USER_ID)
-            }.join()
+            eventRepo.updateParticipants(testEvent.name, USER_ID)
             var event = eventRepo.getEventById(testEvent.name)
             assertNotNull(event)
             assertEquals(testEvent.name, event!!.name)
             assertEquals(1, event.numParticipants)
             assert(event.participants.contains(USER_ID))
 
-            launch {
-                eventRepo.updateParticipants(testEvent.name, USER_ID)
-            }.join()
+            eventRepo.updateParticipants(testEvent.name, USER_ID)
             event = eventRepo.getEventById(testEvent.name)
             assertNotNull(event)
             assertEquals(testEvent.name, event!!.name)

--- a/app/src/androidTest/java/com/github/sdp/ratemyepfl/database/EventRepositoryTest.kt
+++ b/app/src/androidTest/java/com/github/sdp/ratemyepfl/database/EventRepositoryTest.kt
@@ -80,14 +80,14 @@ class EventRepositoryTest {
     @Test
     fun changeNumParticipantsWorks() {
         runTest {
-            eventRepo.updateParticipants(testEvent.name, USER_ID).await()
+            eventRepo.updateParticipants(testEvent.name, USER_ID)
             var event = eventRepo.getEventById(testEvent.name)
             assertNotNull(event)
             assertEquals(testEvent.name, event!!.name)
             assertEquals(1, event.numParticipants)
             assert(event.participants.contains(USER_ID))
 
-            eventRepo.updateParticipants(testEvent.name, USER_ID).await()
+            eventRepo.updateParticipants(testEvent.name, USER_ID)
             event = eventRepo.getEventById(testEvent.name)
             assertNotNull(event)
             assertEquals(testEvent.name, event!!.name)

--- a/app/src/androidTest/java/com/github/sdp/ratemyepfl/database/fakes/FakeEventRepository.kt
+++ b/app/src/androidTest/java/com/github/sdp/ratemyepfl/database/fakes/FakeEventRepository.kt
@@ -3,9 +3,6 @@ package com.github.sdp.ratemyepfl.database.fakes
 import com.github.sdp.ratemyepfl.database.reviewable.EventRepository
 import com.github.sdp.ratemyepfl.model.items.Event
 import com.github.sdp.ratemyepfl.model.review.ReviewRating
-import com.google.android.gms.tasks.Task
-import com.google.firebase.firestore.Transaction
-import org.mockito.Mockito
 import java.time.LocalDateTime
 import javax.inject.Inject
 
@@ -51,8 +48,8 @@ class FakeEventRepository @Inject constructor() : EventRepository {
 
     override suspend fun getEventById(id: String): Event = eventById
 
-    override suspend fun updateParticipants(eventId: String, userId: String): Task<Transaction> =
-        Mockito.mock(Task::class.java) as Task<Transaction>
+    override suspend fun updateParticipants(eventId: String, userId: String): Boolean =
+        true
 
     override suspend fun updateEventRating(id: String, rating: ReviewRating) {
         rate = rating

--- a/app/src/main/java/com/github/sdp/ratemyepfl/database/reviewable/EventRepository.kt
+++ b/app/src/main/java/com/github/sdp/ratemyepfl/database/reviewable/EventRepository.kt
@@ -2,8 +2,6 @@ package com.github.sdp.ratemyepfl.database.reviewable
 
 import com.github.sdp.ratemyepfl.model.items.Event
 import com.github.sdp.ratemyepfl.model.review.ReviewRating
-import com.google.android.gms.tasks.Task
-import com.google.firebase.firestore.Transaction
 
 interface EventRepository {
     /**
@@ -21,9 +19,10 @@ interface EventRepository {
     suspend fun getEventById(id: String): Event?
 
     /**
-     *  Increment the number of participants of given event
+     *  Update the number of participants of given event if possible, and returns
+     *  weither this function has succeeded or not
      */
-    suspend fun updateParticipants(eventId: String, userId: String): Task<Transaction>
+    suspend fun updateParticipants(eventId: String, userId: String): Boolean
 
     /**
      *  Updates the rating of the event using a transaction for concurrency

--- a/app/src/main/java/com/github/sdp/ratemyepfl/database/reviewable/EventRepositoryImpl.kt
+++ b/app/src/main/java/com/github/sdp/ratemyepfl/database/reviewable/EventRepositoryImpl.kt
@@ -6,10 +6,8 @@ import com.github.sdp.ratemyepfl.database.reviewable.ReviewableRepositoryImpl.Co
 import com.github.sdp.ratemyepfl.database.reviewable.ReviewableRepositoryImpl.Companion.NUM_REVIEWS_FIELD_NAME
 import com.github.sdp.ratemyepfl.model.items.Event
 import com.github.sdp.ratemyepfl.model.review.ReviewRating
-import com.google.android.gms.tasks.Task
 import com.google.firebase.firestore.DocumentSnapshot
 import com.google.firebase.firestore.FirebaseFirestore
-import com.google.firebase.firestore.Transaction
 import com.google.firebase.firestore.ktx.getField
 import kotlinx.coroutines.tasks.await
 import java.time.LocalDateTime
@@ -74,19 +72,29 @@ class EventRepositoryImpl private constructor(val repository: ReviewableReposito
 
     override suspend fun getEventById(id: String): Event? = getById(id).toEvent()
 
-    override suspend fun updateParticipants(eventId: String, userId: String): Task<Transaction> = repository
-        .update(eventId) { event ->
-            if (!event.participants.contains(userId))
-                event.copy(
-                    numParticipants = event.numParticipants + 1,
-                    participants = event.participants.plus(userId)
-                )
-            else
+    override suspend fun updateParticipants(eventId: String, userId: String): Boolean {
+        var success = true
+        repository.update(eventId) { event ->
+            if (!event.participants.contains(userId)) {
+                if (event.numParticipants == event.limitParticipants) {
+                    success = false
+                    event
+                } else {
+                    event.copy(
+                        numParticipants = event.numParticipants + 1,
+                        participants = event.participants.plus(userId)
+                    )
+                }
+            } else {
                 event.copy(
                     numParticipants = event.numParticipants - 1,
                     participants = event.participants.minus(userId)
                 )
-        }
+            }
+        }.await()
+        return success
+    }
+
 
     override suspend fun updateEventRating(id: String, rating: ReviewRating) {
         repository.update(id) { event ->

--- a/app/src/main/java/com/github/sdp/ratemyepfl/fragment/navigation/EventFragment.kt
+++ b/app/src/main/java/com/github/sdp/ratemyepfl/fragment/navigation/EventFragment.kt
@@ -72,12 +72,10 @@ class EventFragment : Fragment(R.layout.layout_event_list) {
     private fun registrationListener(event: Event) {
         if (auth.isLoggedIn()) {
             val uid = auth.getUserId()!! // Can't be null as we checked that the user is logged in
-            if (!event.participants.contains(uid) && event.numParticipants == event.limitParticipants) {
+            if (!viewModel.updateRegistration(event, uid)) {
                 Snackbar.make(requireView(), R.string.full_event_text, Snackbar.LENGTH_SHORT)
                     .setAnchorView(R.id.activityMainBottomNavigationView)
                     .show()
-            } else {
-                viewModel.updateRegistration(event, uid)
             }
         } else {
             Snackbar.make(requireView(), R.string.registration_no_login_text, Snackbar.LENGTH_SHORT)

--- a/app/src/main/java/com/github/sdp/ratemyepfl/viewmodel/EventListViewModel.kt
+++ b/app/src/main/java/com/github/sdp/ratemyepfl/viewmodel/EventListViewModel.kt
@@ -7,6 +7,7 @@ import com.github.sdp.ratemyepfl.database.reviewable.EventRepository
 import com.github.sdp.ratemyepfl.model.items.Event
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import javax.inject.Inject
 
 /**
@@ -29,8 +30,8 @@ class EventListViewModel @Inject constructor(private val repository: EventReposi
      * Update the participation of the user and return if the update succeeded
      */
     fun updateRegistration(event: Event, userId: String): Boolean {
-        var success = true
-        viewModelScope.launch {
+        var success: Boolean
+        runBlocking {
             success = repository.updateParticipants(event.getId(), userId)
             updateEventsList()
         }

--- a/app/src/main/java/com/github/sdp/ratemyepfl/viewmodel/EventListViewModel.kt
+++ b/app/src/main/java/com/github/sdp/ratemyepfl/viewmodel/EventListViewModel.kt
@@ -26,12 +26,15 @@ class EventListViewModel @Inject constructor(private val repository: EventReposi
     }
 
     /**
-     * Update the participation of the user
+     * Update the participation of the user and return if the update succeeded
      */
-    fun updateRegistration(event: Event, userId: String) {
+    fun updateRegistration(event: Event, userId: String): Boolean {
+        var success = true
         viewModelScope.launch {
-            repository.updateParticipants(event.getId(), userId).continueWith { updateEventsList() }
+            success = repository.updateParticipants(event.getId(), userId)
+            updateEventsList()
         }
+        return success
     }
 
     fun updateEventsList() {


### PR DESCRIPTION
Fix the following concurrency problem when registrating for an event:

If I have the event fragment opened on my smartphone and someone is registering for an event, I can register for this event too (after he's done) even if the limit has been reached by this new registration.